### PR TITLE
Add basic configuration validation acceptance test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,31 @@ jobs:
           bundler-cache: true
       - name: Run tests
         run: bundle exec rake
+
+  acceptance:
+    needs: setup_matrix
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_WITHOUT: development:test:release
+    strategy:
+      fail-fast: false
+      matrix:
+        setfile: ${{fromJson(needs.setup_matrix.outputs.beaker_setfiles)}}
+        puppet: ${{fromJson(needs.setup_matrix.outputs.puppet_major_versions)}}
+    name: ${{ matrix.puppet.name }} - ${{ matrix.setfile.name }}
+    steps:
+      - name: Enable IPv6 on docker
+        run: |
+          echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
+          sudo service docker restart
+      - uses: actions/checkout@v2
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec rake beaker
+        env:
+          BEAKER_PUPPET_COLLECTION: ${{ matrix.puppet.collection }}
+          BEAKER_setfile: ${{ matrix.setfile.value }}

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,3 +1,6 @@
 ---
 spec/spec_helper.rb:
   mock_with: ':mocha'
+
+spec/spec_helper_acceptance.rb:
+  unmanaged: false

--- a/spec/acceptance/default_spec.rb
+++ b/spec/acceptance/default_spec.rb
@@ -4,7 +4,8 @@ describe 'nftables class' do
   context 'configure default nftables service' do
     it 'works idempotently with no errors' do
       pp = <<-EOS
-      # default mask of firewalld service fails if service not installed.
+      # default mask of firewalld service fails if service is not installed.
+      # https://tickets.puppetlabs.com/browse/PUP-10814
       class { 'nftables':
         firewalld_enable => false,
       }

--- a/spec/acceptance/default_spec.rb
+++ b/spec/acceptance/default_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper_acceptance'
+
+describe 'nftables class' do
+  context 'configure default nftables service' do
+    it 'works idempotently with no errors' do
+      pp = <<-EOS
+      # default mask of firewalld service fails if service not installed.
+      class { 'nftables':
+        firewalld_enable => false,
+      }
+      # nftables cannot be started in docker so replace service with a validation only.
+      systemd::dropin_file{"zzz_docker_nft.conf":
+        ensure  => present,
+        unit    => "nftables.service",
+        content => [
+          "[Service]",
+          "ExecStart=",
+          "ExecStart=/sbin/nft -c -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf",
+          "ExecReload=",
+          "ExecReload=/sbin/nft -c -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf",
+          "",
+          ].join("\n"),
+        notify  => Service["nftables"],
+      }
+      # Puppet 5 only to ensure ordering.
+      Class['systemd::systemctl::daemon_reload'] -> Service['nftables']
+      EOS
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe package('nftables') do
+      it { is_expected.to be_installed }
+    end
+
+    describe service('nftables') do
+      it { is_expected.to be_running }
+      it { is_expected.to be_enabled }
+    end
+
+    describe file('/etc/nftables/puppet.nft') do
+      it { is_expected.to be_file }
+    end
+
+    describe file('/etc/nftables/puppet') do
+      it { is_expected.to be_directory }
+    end
+  end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,6 @@
+# This file is completely managed via modulesync
+require 'voxpupuli/acceptance/spec_helper_acceptance'
+
+configure_beaker
+
+Dir['./spec/support/acceptance/**/*.rb'].sort.each { |f| require f }


### PR DESCRIPTION
#### Add basic configuration validation acceptance test

It is not possible to start the nftables service within docker so
the service is altered to only validate the service
configuration resulting from concat constructed files and nft inclusions.
