### PR TITLE
Comment why firewalld_enable parameter is required

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -152,6 +152,8 @@ class nftables (
     notify  => Service['nftables'],
   }
 
+  # firewalld.enable can be mask or false depending upon if firewalld is installed or not
+  # https://tickets.puppetlabs.com/browse/PUP-10814
   service { 'firewalld':
     ensure => stopped,
     enable => $firewalld_enable,


### PR DESCRIPTION
#### Comment why firewalld_enable parameter is required
service.firewalld.enable being default masked or false is due to a missing feature in puppet.
Add a comment 

https://tickets.puppetlabs.com/browse/PUP-10814

