### PR TITLE
WIP - fix #45 - add custom_file define

### DIFF
--- a/manifests/custom_file.pp
+++ b/manifests/custom_file.pp
@@ -1,0 +1,29 @@
+# manage a custom config file as it is
+define nftables::custom_file (
+  Optional[String] $content = undef,
+  Optional[Variant[String,Array[String,1]]] $source = undef,
+) {
+  Package['nftables'] -> file {
+    "/etc/nftables/puppet-preflight/${name}.nft":
+      owner => root,
+      group => root,
+      mode  => '0640',
+  } ~> Exec['nft validate'] -> file {
+    "/etc/nftables/puppet/${name}.nft":
+      ensure => file,
+      source => "/etc/nftables/puppet-preflight/${name}.nft",
+      owner  => root,
+      group  => root,
+      mode   => '0640',
+  } ~> Service['nftables']
+
+  if $source {
+    File["/etc/nftables/puppet-preflight/${name}.nft"]{
+      source => $source,
+    }
+  } else {
+    File["/etc/nftables/puppet-preflight/${name}.nft"]{
+      content => $content,
+    }
+  }
+}


### PR DESCRIPTION
This is a WIP for the issue in #49 and how I am now deploying custom configs.

We could even hardcode the `custom-` in front.

Once the design is clear, I could add tests and fix documentation.