### PR TITLE
Several fixes for nftables::config

### DIFF
--- a/files/config/puppet-ip-nat.nft
+++ b/files/config/puppet-ip-nat.nft
@@ -1,1 +1,0 @@
-  include "ip-nat-chain-*.nft"

--- a/files/config/puppet-ip6-nat.nft
+++ b/files/config/puppet-ip6-nat.nft
@@ -1,1 +1,0 @@
-  include "ip6-nat-chain-*.nft"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,5 +1,6 @@
 # manage a config snippet
 define nftables::config (
+  Pattern[/^\w+-\w+$/] $tablespec = $title,
   Optional[String] $content = undef,
   Optional[Variant[String,Array[String,1]]] $source = undef,
 ) {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -38,11 +38,16 @@ define nftables::config (
         source => $source,
     }
   } else {
+    if $content {
+      $_content = $content
+    } else {
+      $_content = "  include \"${name}-chain-*.nft\""
+    }
     concat::fragment {
       "${concat_name}-body":
         target  => $concat_name,
         order   => '98',
-        content => $content,
+        content => $_content,
     }
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,6 +3,10 @@ define nftables::config (
   Optional[String] $content = undef,
   Optional[Variant[String,Array[String,1]]] $source = undef,
 ) {
+  if $content and $source {
+    fail('Please pass only $content or $source, not both.')
+  }
+
   $concat_name = "nftables-${name}"
 
   Package['nftables'] -> concat {

--- a/manifests/ip_nat.pp
+++ b/manifests/ip_nat.pp
@@ -1,11 +1,6 @@
 # manage basic chains in table ip nat
 class nftables::ip_nat inherits nftables {
-  nftables::config {
-    'ip-nat':
-      source => 'puppet:///modules/nftables/config/puppet-ip-nat.nft';
-    'ip6-nat':
-      source => 'puppet:///modules/nftables/config/puppet-ip6-nat.nft';
-  }
+  nftables::config { ['ip-nat', 'ip6-nat']: }
 
   nftables::chain {
     [

--- a/spec/classes/ip_nat_spec.rb
+++ b/spec/classes/ip_nat_spec.rb
@@ -30,6 +30,7 @@ describe 'nftables' do
       it {
         is_expected.to contain_concat__fragment('nftables-ip-nat-body').with(
           target:  'nftables-ip-nat',
+          content: %r{^\s+include "ip-nat-chain-\*\.nft"$},
           order:   '98',
         )
       }
@@ -63,6 +64,7 @@ describe 'nftables' do
       it {
         is_expected.to contain_concat__fragment('nftables-ip6-nat-body').with(
           target:  'nftables-ip6-nat',
+          content: %r{^\s+include "ip6-nat-chain-\*\.nft"$},
           order:   '98',
         )
       }

--- a/spec/defines/config_spec.rb
+++ b/spec/defines/config_spec.rb
@@ -11,7 +11,38 @@ describe 'nftables::config' do
       end
 
       context 'with source and content both unset' do
-        it { is_expected.not_to compile }
+        it { is_expected.to compile }
+        it { is_expected.to contain_concat('nftables-FOO-BAR') }
+        it {
+          is_expected.to contain_concat('nftables-FOO-BAR').with(
+            path: '/etc/nftables/puppet-preflight/FOO-BAR.nft',
+            ensure_newline: true,
+            mode: '0640',
+          )
+        }
+        it { is_expected.to contain_file('/etc/nftables/puppet/FOO-BAR.nft') }
+        it {
+          is_expected.to contain_file('/etc/nftables/puppet/FOO-BAR.nft').with(
+            ensure: 'file',
+            source: '/etc/nftables/puppet-preflight/FOO-BAR.nft',
+            mode: '0640',
+          )
+        }
+        it { is_expected.to contain_concat_fragment('nftables-FOO-BAR-header') }
+        it {
+          is_expected.to contain_concat_fragment('nftables-FOO-BAR-header').with(
+            target: 'nftables-FOO-BAR',
+            order: '00',
+            content: 'table FOO BAR {',
+          )
+        }
+        it {
+          is_expected.to contain_concat_fragment('nftables-FOO-BAR-body').with(
+            target: 'nftables-FOO-BAR',
+            order: '98',
+            content: '  include "FOO-BAR-chain-*.nft"',
+          )
+        }
       end
 
       context 'with a non hyphenated title' do

--- a/spec/defines/config_spec.rb
+++ b/spec/defines/config_spec.rb
@@ -60,7 +60,6 @@ describe 'nftables::config' do
         end
 
         it {
-          pending('Setting source and content should be made to fail')
           is_expected.not_to compile
         }
       end

--- a/spec/defines/config_spec.rb
+++ b/spec/defines/config_spec.rb
@@ -103,7 +103,7 @@ describe 'nftables::config' do
           )
         }
       end
-      context 'with content set' do
+      context 'with source set' do
         let(:params) do
           {
             source: 'puppet:///modules/foo',


### PR DESCRIPTION
A few improvements to `nftables::config`, derived from #45.

* Autogenerate the statement to include chains to save templates for the simple cases
* Actually fail if both `content` and `source` are passed (this was a TODO, I believe)
* Remove duplicate context name
* Kind of validate the resource title so all tests pass

This patch complements (and might conflict with) #47 