### PR TITLE
Use Stdlib::Port everywhere in place of Integer

### DIFF
--- a/manifests/rules/ceph_mon.pp
+++ b/manifests/rules/ceph_mon.pp
@@ -1,7 +1,7 @@
 # Ceph is a distributed object store and file system.
 # Enable this option to support Ceph's Monitor Daemon.
 class nftables::rules::ceph_mon (
-  Array[Integer,1] $ports = [3300, 6789],
+  Array[Stdlib::Port,1] $ports = [3300, 6789],
 ) {
   nftables::rule {
     'default_in-ceph_mon':

--- a/manifests/rules/dnat4.pp
+++ b/manifests/rules/dnat4.pp
@@ -1,13 +1,13 @@
 # manage a ipv4 dnat rule
 define nftables::rules::dnat4 (
   Pattern[/^[12]?\d{1,2}\.[12]?\d{1,2}\.[12]?\d{1,2}\.[12]?\d{1,2}$/] $daddr,
-  Variant[String,Integer[1,65535]] $port,
+  Variant[String,Stdlib::Port] $port,
   Pattern[/^[a-zA-Z0-9_]+$/] $rulename = $title,
   Pattern[/^\d\d$/] $order = '50',
   String[1] $chain = 'default_fwd',
   Optional[String[1]] $iif = undef,
   Enum['tcp','udp'] $proto = 'tcp',
-  Optional[Variant[String,Integer[1,65535]]] $dport = '',
+  Optional[Variant[String,Stdlib::Port]] $dport = '',
   Enum['present','absent'] $ensure = 'present',
 ) {
   $iifname = $iif ? {

--- a/manifests/rules/dns.pp
+++ b/manifests/rules/dns.pp
@@ -1,6 +1,6 @@
 # manage in dns
 class nftables::rules::dns (
-  Array[Integer,1] $ports = [53],
+  Array[Stdlib::Port,1] $ports = [53],
 ) {
   nftables::rule {
     'default_in-dns_tcp':

--- a/manifests/rules/icinga2.pp
+++ b/manifests/rules/icinga2.pp
@@ -1,6 +1,6 @@
 # manage in icinga2
 class nftables::rules::icinga2 (
-  Array[Integer,1] $ports = [5665],
+  Array[Stdlib::Port,1] $ports = [5665],
 ) {
   nftables::rule {
     'default_in-icinga2':

--- a/manifests/rules/masquerade.pp
+++ b/manifests/rules/masquerade.pp
@@ -7,7 +7,7 @@ define nftables::rules::masquerade (
   Optional[String[1]] $saddr = undef,
   Optional[String[1]] $daddr = undef,
   Optional[Enum['tcp','udp']] $proto = undef,
-  Optional[Variant[String,Integer[1,65535]]] $dport = undef,
+  Optional[Variant[String,Stdlib::Port]] $dport = undef,
   Enum['present','absent'] $ensure = 'present',
 ) {
   $oifname = $oif ? {

--- a/manifests/rules/node_exporter.pp
+++ b/manifests/rules/node_exporter.pp
@@ -1,7 +1,7 @@
 # manage in node exporter
 class nftables::rules::node_exporter (
   Optional[Variant[String,Array[String,1]]] $prometheus_server = undef,
-  Integer $port = 9100,
+  Stdlib::Port $port = 9100,
 ) {
   if $prometheus_server {
     any2array($prometheus_server).each |$index,$prom| {

--- a/manifests/rules/out/ceph_client.pp
+++ b/manifests/rules/out/ceph_client.pp
@@ -3,7 +3,7 @@
 # Object Storage Daemons (OSD), Metadata Server Daemons (MDS),
 # and Manager Daemons (MGR).
 class nftables::rules::out::ceph_client (
-  Array[Integer,1] $ports = [3300, 6789],
+  Array[Stdlib::Port,1] $ports = [3300, 6789],
 ) {
   nftables::rule {
     'default_out-ceph_client':

--- a/manifests/rules/out/openafs_client.pp
+++ b/manifests/rules/out/openafs_client.pp
@@ -6,7 +6,7 @@
 # @see https://wiki.openafs.org/devel/AFSServicePorts/ AFS Service Ports
 #
 class nftables::rules::out::openafs_client (
-  Array[Integer,1] $ports = [7000, 7002, 7003],
+  Array[Stdlib::Port,1] $ports = [7000, 7002, 7003],
 ) {
   include nftables::rules::out::kerberos
 

--- a/manifests/rules/out/puppet.pp
+++ b/manifests/rules/out/puppet.pp
@@ -1,7 +1,7 @@
 # manage outgoing puppet
 class nftables::rules::out::puppet (
   Variant[Stdlib::IP::Address,Array[Stdlib::IP::Address,1]] $puppetserver,
-  Integer $puppetserver_port = 8140,
+  Stdlib::Port $puppetserver_port = 8140,
 ) {
   Array($puppetserver, true).each |$index,$ps| {
     nftables::rule {

--- a/manifests/rules/snat4.pp
+++ b/manifests/rules/snat4.pp
@@ -7,7 +7,7 @@ define nftables::rules::snat4 (
   Optional[String[1]] $oif = undef,
   Optional[String[1]] $saddr = undef,
   Optional[Enum['tcp','udp']] $proto = undef,
-  Optional[Variant[String,Integer[1,65535]]] $dport = undef,
+  Optional[Variant[String,Stdlib::Port]] $dport = undef,
   Enum['present','absent'] $ensure = 'present',
 ) {
   $oifname = $oif ? {

--- a/manifests/rules/ssh.pp
+++ b/manifests/rules/ssh.pp
@@ -1,6 +1,6 @@
 # manage in ssh
 class nftables::rules::ssh (
-  Array[Integer,1] $ports = [22],
+  Array[Stdlib::Port,1] $ports = [22],
 ) {
   nftables::rule {
     'default_in-ssh':

--- a/manifests/rules/tor.pp
+++ b/manifests/rules/tor.pp
@@ -1,6 +1,6 @@
 # manage in tor
 class nftables::rules::tor (
-  Array[Integer,1] $ports = [9001],
+  Array[Stdlib::Port,1] $ports = [9001],
 ) {
   nftables::rule {
     'default_in-tor':

--- a/manifests/rules/wireguard.pp
+++ b/manifests/rules/wireguard.pp
@@ -1,6 +1,6 @@
 # manage in wireguard
 class nftables::rules::wireguard (
-  Array[Integer,1] $ports = [51820],
+  Array[Stdlib::Port,1] $ports = [51820],
 ) {
   nftables::rule {
     'default_in-wireguard':

--- a/spec/classes/rules/dns_spec.rb
+++ b/spec/classes/rules/dns_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'nftables::rules::dns' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'default options' do
+        it { is_expected.to compile }
+        it { is_expected.to contain_nftables__rule('default_in-dns_tcp').with_content('tcp dport {53} accept') }
+        it { is_expected.to contain_nftables__rule('default_in-dns_udp').with_content('udp dport {53} accept') }
+      end
+
+      context 'with ports set' do
+        let(:params) do
+          {
+            ports: [55, 60],
+          }
+        end
+
+        it { is_expected.to compile }
+        it { is_expected.to contain_nftables__rule('default_in-dns_tcp').with_content('tcp dport {55, 60} accept') }
+        it { is_expected.to contain_nftables__rule('default_in-dns_udp').with_content('udp dport {55, 60} accept') }
+      end
+    end
+  end
+end

--- a/spec/classes/rules/icinga2_spec.rb
+++ b/spec/classes/rules/icinga2_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe 'nftables::rules::icinga2' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'default options' do
+        it { is_expected.to compile }
+        it { is_expected.to contain_nftables__rule('default_in-icinga2').with_content('tcp dport {5665} accept') }
+      end
+
+      context 'with ports set' do
+        let(:params) do
+          {
+            ports: [55, 60],
+          }
+        end
+
+        it { is_expected.to compile }
+        it { is_expected.to contain_nftables__rule('default_in-icinga2').with_content('tcp dport {55, 60} accept') }
+      end
+    end
+  end
+end

--- a/spec/classes/rules/node_exporter_spec.rb
+++ b/spec/classes/rules/node_exporter_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe 'nftables::rules::node_exporter' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'default options' do
+        it { is_expected.to compile }
+        it { is_expected.to contain_nftables__rule('default_in-node_exporter').with_content('tcp dport 9100 accept') }
+      end
+
+      context 'with port set' do
+        let(:params) do
+          {
+            port: 100,
+          }
+        end
+
+        it { is_expected.to compile }
+        it { is_expected.to contain_nftables__rule('default_in-node_exporter').with_content('tcp dport 100 accept') }
+        context 'with prometheus_server set' do
+          let(:params) do
+            super().merge({ prometheus_server: ['127.0.0.1', '::1'] })
+          end
+
+          it { is_expected.to contain_nftables__rule('default_in-node_exporter-0').with_content('ip saddr 127.0.0.1 tcp dport 100 accept') }
+          it { is_expected.to contain_nftables__rule('default_in-node_exporter-1').with_content('ip6 saddr ::1 tcp dport 100 accept') }
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/rules/ssh_spec.rb
+++ b/spec/classes/rules/ssh_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe 'nftables::rules::ssh' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'default options' do
+        it { is_expected.to compile }
+        it { is_expected.to contain_nftables__rule('default_in-ssh').with_content('tcp dport {22} accept') }
+      end
+
+      context 'with ports set' do
+        let(:params) do
+          {
+            ports: [55, 60],
+          }
+        end
+
+        it { is_expected.to compile }
+        it { is_expected.to contain_nftables__rule('default_in-ssh').with_content('tcp dport {55, 60} accept') }
+      end
+    end
+  end
+end

--- a/spec/classes/rules/tor_spec.rb
+++ b/spec/classes/rules/tor_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe 'nftables::rules::tor' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'default options' do
+        it { is_expected.to compile }
+        it { is_expected.to contain_nftables__rule('default_in-tor').with_content('tcp dport {9001} accept') }
+      end
+
+      context 'with ports set' do
+        let(:params) do
+          {
+            ports: [55, 60],
+          }
+        end
+
+        it { is_expected.to compile }
+        it { is_expected.to contain_nftables__rule('default_in-tor').with_content('tcp dport {55, 60} accept') }
+      end
+    end
+  end
+end

--- a/spec/classes/rules/wireguard_spec.rb
+++ b/spec/classes/rules/wireguard_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe 'nftables::rules::wireguard' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'default options' do
+        it { is_expected.to compile }
+        it { is_expected.to contain_nftables__rule('default_in-wireguard').with_content('udp dport {51820} accept') }
+      end
+
+      context 'with ports set' do
+        let(:params) do
+          {
+            ports: [55, 60],
+          }
+        end
+
+        it { is_expected.to compile }
+        it { is_expected.to contain_nftables__rule('default_in-wireguard').with_content('udp dport {55, 60} accept') }
+      end
+    end
+  end
+end

--- a/spec/defines/rules/dnat4_spec.rb
+++ b/spec/defines/rules/dnat4_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe 'nftables::rules::dnat4' do
+  let(:title) { 'foobar' }
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+
+      context 'with minumum parameters' do
+        let(:params) do
+          {
+            daddr: '127.127.127.127',
+            port: 100,
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+      end
+    end
+  end
+end

--- a/spec/defines/rules/masquerade_spec.rb
+++ b/spec/defines/rules/masquerade_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'nftables::rules::masquerade' do
+  let(:title) { 'foobar' }
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+
+      context 'with default parameters' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_nftables__rule('POSTROUTING-foobar').with_content('masquerade') }
+      end
+      context 'with dport specified' do
+        let(:params) do
+          {
+            dport: 1000
+          }
+        end
+
+        it { is_expected.to contain_nftables__rule('POSTROUTING-foobar').with_content('tcp dport 1000 masquerade') }
+      end
+    end
+  end
+end

--- a/spec/defines/rules/snat4_spec.rb
+++ b/spec/defines/rules/snat4_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'nftables::rules::snat4' do
+  let(:title) { 'foobar' }
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+
+      context 'with snat specified' do
+        let(:params) do
+          {
+            snat: 'sausage',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_nftables__rule('POSTROUTING-foobar').with_content('snat sausage') }
+        context 'with dport specified' do
+          let(:params) do
+            super().merge(dport: 1234)
+          end
+
+          it { is_expected.to contain_nftables__rule('POSTROUTING-foobar').with_content('tcp dport 1234 snat sausage') }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Use Stdlib::Port in place of Integer for ports
Use Stdlib::Port for all port parameters.

#### This Pull Request (PR) fixes the following issues
Fixes #37

