### PR TITLE
Align simplerule and rule rulename requirements

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1286,7 +1286,7 @@ Default value: `'present'`
 
 ##### `rulename`
 
-Data type: `Pattern[/^[-a-zA-Z0-9_]+$/]`
+Data type: `Pattern[/^[a-zA-Z0-9_]+(-\d+)?$/]`
 
 The symbolic name for the rule to add. Defaults to the resource's title.
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -74,6 +74,11 @@
 * [`Nftables::Addr::Set`](#nftablesaddrset): Represents a set expression to be used within a rule.
 * [`Nftables::Port`](#nftablesport): Represents a port expression to be used within a rule.
 * [`Nftables::Port::Range`](#nftablesportrange): Represents a port range expression to be used within a rule.
+* [`Nftables::RuleName`](#nftablesrulename): Represents a rule name to be used in a raw rule created via nftables::rule.
+It's a dash separated string. The first component describes the chain to
+add the rule to, the second the rule name and the (optional) third a number.
+Ex: 'default_in-sshd', 'default_out-my_service-2'.
+* [`Nftables::SimpleRuleName`](#nftablessimplerulename): Represents a simple rule name to be used in a rule created via nftables::simplerule
 
 ## Classes
 
@@ -847,7 +852,7 @@ Default value: `'present'`
 
 ##### `rulename`
 
-Data type: `Pattern[/^[a-zA-Z0-9_]+-[a-zA-Z0-9_]+(-\d+)?$/]`
+Data type: `Nftables::RuleName`
 
 
 
@@ -1286,7 +1291,7 @@ Default value: `'present'`
 
 ##### `rulename`
 
-Data type: `Pattern[/^[a-zA-Z0-9_]+(-\d+)?$/]`
+Data type: `Nftables::SimpleRuleName`
 
 The symbolic name for the rule to add. Defaults to the resource's title.
 
@@ -1414,4 +1419,19 @@ Alias of `Variant[Array[Stdlib::Port, 1], Stdlib::Port, Nftables::Port::Range]`
 Represents a port range expression to be used within a rule.
 
 Alias of `Pattern[/^\d+-\d+$/]`
+
+### `Nftables::RuleName`
+
+Represents a rule name to be used in a raw rule created via nftables::rule.
+It's a dash separated string. The first component describes the chain to
+add the rule to, the second the rule name and the (optional) third a number.
+Ex: 'default_in-sshd', 'default_out-my_service-2'.
+
+Alias of `Pattern[/^[a-zA-Z0-9_]+-[a-zA-Z0-9_]+(-\d+)?$/]`
+
+### `Nftables::SimpleRuleName`
+
+Represents a simple rule name to be used in a rule created via nftables::simplerule
+
+Alias of `Pattern[/^[a-zA-Z0-9_]+(-\d+)?$/]`
 

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -3,7 +3,7 @@
 #   CHAIN_NAME-rulename
 define nftables::rule (
   Enum['present','absent'] $ensure = 'present',
-  Pattern[/^[a-zA-Z0-9_]+-[a-zA-Z0-9_]+(-\d+)?$/] $rulename = $title,
+  Nftables::RuleName $rulename = $title,
   Pattern[/^\d\d$/] $order = '50',
   Optional[String] $table = 'inet-filter',
   Optional[String] $content = undef,

--- a/manifests/simplerule.pp
+++ b/manifests/simplerule.pp
@@ -54,7 +54,7 @@
 #   Enable traffic counters for the matched traffic.
 define nftables::simplerule (
   Enum['present','absent'] $ensure = 'present',
-  Pattern[/^[-a-zA-Z0-9_]+$/] $rulename = $title,
+  Pattern[/^[a-zA-Z0-9_]+(-\d+)?$/] $rulename = $title,
   Pattern[/^\d\d$/] $order = '50',
   String $chain  = 'default_in',
   String $table = 'inet-filter',

--- a/manifests/simplerule.pp
+++ b/manifests/simplerule.pp
@@ -54,7 +54,7 @@
 #   Enable traffic counters for the matched traffic.
 define nftables::simplerule (
   Enum['present','absent'] $ensure = 'present',
-  Pattern[/^[a-zA-Z0-9_]+(-\d+)?$/] $rulename = $title,
+  Nftables::SimpleRuleName $rulename = $title,
   Pattern[/^\d\d$/] $order = '50',
   String $chain  = 'default_in',
   String $table = 'inet-filter',

--- a/spec/defines/simplerule_spec.rb
+++ b/spec/defines/simplerule_spec.rb
@@ -272,6 +272,12 @@ describe 'nftables::simplerule' do
           )
         }
       end
+
+      describe 'illegal rule name' do
+        let(:title) { 'my_wrongrule-name' }
+
+        it { is_expected.to compile.and_raise_error(%r{Error while evaluating a Resource Statement, Nftables::Simplerule}) }
+      end
     end
   end
 end

--- a/spec/defines/simplerule_spec.rb
+++ b/spec/defines/simplerule_spec.rb
@@ -272,12 +272,6 @@ describe 'nftables::simplerule' do
           )
         }
       end
-
-      describe 'illegal rule name' do
-        let(:title) { 'my_wrongrule-name' }
-
-        it { is_expected.to compile.and_raise_error(%r{Error while evaluating a Resource Statement, Nftables::Simplerule}) }
-      end
     end
   end
 end

--- a/spec/type_aliases/nftables_rulename_spec.rb
+++ b/spec/type_aliases/nftables_rulename_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe 'Nftables::RuleName' do
+  it { is_expected.to allow_value('chain-rule') }
+  it { is_expected.to allow_value('Chain_name-Rule_name') }
+  it { is_expected.to allow_value('chain5_name0-rule_name-3') }
+  it { is_expected.to allow_value('chain_name-rule2_name-33') }
+  it { is_expected.to allow_value('chainname-3') }
+  it { is_expected.not_to allow_value('-rule_name-') }
+  it { is_expected.not_to allow_value('rule_name') }
+  it { is_expected.not_to allow_value('chain_name-rule_name-') }
+  it { is_expected.not_to allow_value('chain_name-rule_name-3b') }
+  it { is_expected.not_to allow_value('chain_name-rule_name-foo') }
+end

--- a/spec/type_aliases/nftables_simplerulename_spec.rb
+++ b/spec/type_aliases/nftables_simplerulename_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe 'Nftables::SimpleRuleName' do
+  it { is_expected.to allow_value('rule') }
+  it { is_expected.to allow_value('Rule_name') }
+  it { is_expected.to allow_value('rule_name-3') }
+  it { is_expected.to allow_value('rule_name-33') }
+  it { is_expected.to allow_value('3') }
+  it { is_expected.not_to allow_value('rule_name-') }
+  it { is_expected.not_to allow_value('rule_name-3b') }
+  it { is_expected.not_to allow_value('rule_name-foo') }
+end

--- a/types/rulename.pp
+++ b/types/rulename.pp
@@ -1,0 +1,6 @@
+# @summary
+#   Represents a rule name to be used in a raw rule created via nftables::rule.
+#   It's a dash separated string. The first component describes the chain to
+#   add the rule to, the second the rule name and the (optional) third a number.
+#   Ex: 'default_in-sshd', 'default_out-my_service-2'.
+type Nftables::RuleName = Pattern[/^[a-zA-Z0-9_]+-[a-zA-Z0-9_]+(-\d+)?$/]

--- a/types/simplerulename.pp
+++ b/types/simplerulename.pp
@@ -1,0 +1,3 @@
+# @summary
+#   Represents a simple rule name to be used in a rule created via nftables::simplerule
+type Nftables::SimpleRuleName = Pattern[/^[a-zA-Z0-9_]+(-\d+)?$/]


### PR DESCRIPTION
This patchsets unifies the regular expression that validates the underlying rule name in `nftables::rule` to the expression used in `nftables::simplerule` so it's clearer for the user what's going on if a bad name is used. The caller using `nftables::simplerule` does not necessarily have to know anything about `nftables::rule`.

Fixes #58 
