### PR TITLE
start declaring the 'global' chain with module resources

### DIFF
--- a/files/config/puppet-inet-filter.nft
+++ b/files/config/puppet-inet-filter.nft
@@ -1,5 +1,1 @@
   include "inet-filter-chain-*.nft"
-
-  # something we want for all
-  chain global {
-  }

--- a/manifests/inet_filter.pp
+++ b/manifests/inet_filter.pp
@@ -18,6 +18,7 @@ class nftables::inet_filter inherits nftables {
       'INPUT',
       'OUTPUT',
       'FORWARD',
+      'global',
     ]:;
   }
 

--- a/spec/classes/inet_filter_spec.rb
+++ b/spec/classes/inet_filter_spec.rb
@@ -414,6 +414,25 @@ describe 'nftables' do
         }
       end
 
+      context 'chain global' do
+        it {
+          is_expected.to contain_concat('nftables-inet-filter-chain-global').with(
+            path:           '/etc/nftables/puppet-preflight/inet-filter-chain-global.nft',
+            owner:          'root',
+            group:          'root',
+            mode:           '0640',
+            ensure_newline: true,
+          )
+        }
+        it {
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-global-header').with(
+            target:  'nftables-inet-filter-chain-global',
+            content: %r{^chain global \{$},
+            order:   '00',
+          )
+        }
+      end
+
       context 'custom log prefix without variable substitution' do
         let(:pre_condition) { 'class{\'nftables\': log_prefix => "test "}' }
 


### PR DESCRIPTION
the 'global' chain is a vestigial piece of early development on this
module, but it can be useful for creating fast short-circuits like
blocking traffic that match a certain set of IPs.

in the current state we can't inject rules inside the 'global' chain
since it's unknown to puppet. so let's remove the hard-coded definition
and use a puppet resource to declare it.