### PR TITLE
Drop Puppet 5 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 6.2.0 < 7.0.0"
+      "version_requirement": ">= 6.2.0 < 8.0.0"
     },
     {
       "name": "camptocamp/systemd",
@@ -24,7 +24,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 7.0.0"
+      "version_requirement": ">= 4.13.1 < 8.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -50,7 +50,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.10.0 < 8.0.0"
+      "version_requirement": ">= 6.1.0 < 8.0.0"
     }
   ]
 }


### PR DESCRIPTION
Also bump puppetlabs/concat and puppetlabs/stdlib, whose versions 7.0.0 also dropped support for Puppet 5.

Fixes #78