### PR TITLE
Drop Puppet 5, puppetlabs/concat 7.x, puppetlabs/stdlib 7.x, camptocamp/systemd: 3.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 6.2.0 < 7.0.0"
+      "version_requirement": ">= 6.2.0 < 8.0.0"
     },
     {
       "name": "camptocamp/systemd",

--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "camptocamp/systemd",
-      "version_requirement": ">= 2.0.0 < 3.0.0"
+      "version_requirement": ">= 2.0.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/metadata.json
+++ b/metadata.json
@@ -24,7 +24,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 7.0.0"
+      "version_requirement": ">= 4.13.1 < 8.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/all_rules_spec.rb
+++ b/spec/acceptance/all_rules_spec.rb
@@ -85,8 +85,6 @@ describe 'nftables class' do
           ].join("\n"),
         notify  => Service["nftables"],
       }
-      # Puppet 5 only to ensure ordering.
-      Class['systemd::systemctl::daemon_reload'] -> Service['nftables']
       EOS
       # Run it twice and test for idempotency
       apply_manifest(pp, catch_failures: true)

--- a/spec/acceptance/default_spec.rb
+++ b/spec/acceptance/default_spec.rb
@@ -23,8 +23,6 @@ describe 'nftables class' do
           ].join("\n"),
         notify  => Service["nftables"],
       }
-      # Puppet 5 only to ensure ordering.
-      Class['systemd::systemctl::daemon_reload'] -> Service['nftables']
       EOS
       # Run it twice and test for idempotency
       apply_manifest(pp, catch_failures: true)


### PR DESCRIPTION
#### Pull Request (PR) description
Includes
* #89 camptocamp/systemd: allow 3.x
* #90 puppetlabs/stdlib: Allow 7.x,
* #91 puppetlabs/concat: Allow 7.x
* #79 Drop puppet 5 support