### PR TITLE
Fix IPv4 source address type detection

### DIFF
--- a/spec/defines/simplerule_spec.rb
+++ b/spec/defines/simplerule_spec.rb
@@ -209,6 +209,21 @@ describe 'nftables::simplerule' do
         }
       end
 
+      describe 'with an IPv4 address as saddr' do
+        let(:params) do
+          {
+            saddr: '172.16.1.5',
+          }
+        end
+
+        it { is_expected.to compile }
+        it {
+          is_expected.to contain_nftables__rule('default_in-my_default_rule_name').with(
+            content: 'ip saddr 172.16.1.5 accept',
+          )
+        }
+      end
+
       describe 'with an IPv6 set as daddr, default set_type' do
         let(:params) do
           {

--- a/templates/simplerule.epp
+++ b/templates/simplerule.epp
@@ -38,7 +38,7 @@
 <%- if $saddr {
   if $saddr =~ Stdlib::IP::Address::V6 {
     $_src_hosts = "ip6 saddr ${saddr}"
-  } elsif $daddr =~ Stdlib::IP::Address::V4 {
+  } elsif $saddr =~ Stdlib::IP::Address::V4 {
     $_src_hosts = "ip saddr ${saddr}"
   } else {
     $_src_hosts = $set_type ? {


### PR DESCRIPTION
Before this patch, a rule like this:

```
  nftables::simplerule { 'foo':
    action   => 'accept',
    dport    => 443,
    proto    => 'tcp4',
    saddr    => '192.168.1.10',
  }
```

would incorrectly generate this rule:

```
ip version 4 tcp dport {443} ip6 saddr 192.168.1.10 accept
```

Note the `ip6 saddr`.
