### PR TITLE
Allow creating a totally empty firewall

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ for all masterchains. This chain is empty by default.
 INPUT and OUTPUT to the loopback device is allowed by
 default, though you could restrict it later.
 
+On the other hand, if you don't want any of the default tables, chains
+and rules created by the module, you can set `nftables::inet_filter`
+and/or `nftables::nat` to `false` and build your whole nftables
+configuration from scratch by using the building blocks provided by
+this module. Looking at `nftables::inet_filter` for inspiration might
+be a good idea.
+
 ## Rules Validation
 
 Initially puppet deploys all configuration to

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -131,6 +131,7 @@ The following parameters are available in the `nftables` class:
 * [`out_icmp`](#out_icmp)
 * [`in_ssh`](#in_ssh)
 * [`in_icmp`](#in_icmp)
+* [`inet_filter`](#inet_filter)
 * [`nat`](#nat)
 * [`sets`](#sets)
 * [`log_prefix`](#log_prefix)
@@ -205,6 +206,14 @@ Default value: ``true``
 Data type: `Boolean`
 
 Allow inbound ICMPv4/v6 traffic.
+
+Default value: ``true``
+
+##### <a name="inet_filter"></a>`inet_filter`
+
+Data type: `Boolean`
+
+Add default tables, chains and rules to process traffic.
 
 Default value: ``true``
 

--- a/spec/acceptance/default_spec.rb
+++ b/spec/acceptance/default_spec.rb
@@ -81,4 +81,34 @@ describe 'nftables class' do
       it { is_expected.to be_enabled }
     end
   end
+  context 'with totally empty firewall' do
+    it 'no rules validate okay' do
+      pp = <<-EOS
+      class{'nftables':
+        firewalld_enable => false,
+        inet_filter => false,
+        nat => false,
+      }
+      # nftables cannot be started in docker so replace service with a validation only.
+      systemd::dropin_file{"zzz_docker_nft.conf":
+        ensure  => present,
+        unit    => "nftables.service",
+        content => [
+          "[Service]",
+          "ExecStart=",
+          "ExecStart=/sbin/nft -c -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf",
+          "ExecReload=",
+          "ExecReload=/sbin/nft -c -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf",
+          "",
+          ].join("\n"),
+        notify  => Service["nftables"],
+      }
+      EOS
+      apply_manifest(pp, catch_failures: true)
+    end
+    describe service('nftables') do
+      it { is_expected.to be_running }
+      it { is_expected.to be_enabled }
+    end
+  end
 end

--- a/spec/classes/nftables_spec.rb
+++ b/spec/classes/nftables_spec.rb
@@ -83,6 +83,8 @@ describe 'nftables' do
           enable: 'mask',
         )
       }
+      it { is_expected.to contain_class('nftables::inet_filter') }
+      it { is_expected.to contain_class('nftables::ip_nat') }
       it { is_expected.to contain_class('nftables::rules::out::http') }
       it { is_expected.to contain_class('nftables::rules::out::https') }
       it { is_expected.to contain_class('nftables::rules::out::dns') }
@@ -172,6 +174,33 @@ describe 'nftables' do
             enable: false,
           )
         }
+      end
+
+      context 'with no default filtering rules' do
+        let(:params) do
+          {
+            'inet_filter' => false,
+          }
+        end
+
+        it { is_expected.to contain_class('nftables::ip_nat') }
+        it { is_expected.not_to contain_class('nftables::inet_filter') }
+      end
+
+      context 'with no default tables, chains or rules' do
+        let(:params) do
+          {
+            'inet_filter' => false,
+            'nat' => false,
+          }
+        end
+
+        it { is_expected.not_to contain_class('nftables::ip_nat') }
+        it { is_expected.not_to contain_class('nftables::inet_filter') }
+        it { is_expected.to have_nftables__config_resource_count(0) }
+        it { is_expected.to have_nftables__chain_resource_count(0) }
+        it { is_expected.to have_nftables__rule_resource_count(0) }
+        it { is_expected.to have_nftables__set_resource_count(0) }
       end
 
       context 'with with noflush_tables parameter' do

--- a/templates/config/puppet.nft.epp
+++ b/templates/config/puppet.nft.epp
@@ -1,4 +1,5 @@
 <%- |
+  Boolean $inet_filter,
   Boolean $nat,
   Optional[Array[String[1],1]] $noflush = undef,
 |-%>
@@ -21,7 +22,9 @@ if $noflush and $facts['nftables'] and $facts['nftables']['tables'] {
 <%= $_flush_command.join("\n") %>
 
 include "custom-*.nft"
+<% if $inet_filter { -%>
 include "inet-filter.nft"
+<% } -%>
 <% if $nat { -%>
 include "ip-nat.nft"
 include "ip6-nat.nft"


### PR DESCRIPTION
By setting `nftables::inet_filter` and `nftables::nat` to `false` users can now start off from a totally empty firewall and add the tables, chains and rules they'd like.

The default skeleton for inet-filter, ip-nat and ip6-nat is kept enabled by default.

Fixes #95.