### PR TITLE
Allow declaring the same set in several tables

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1554,9 +1554,9 @@ Default value: ``undef``
 
 ##### <a name="table"></a>`table`
 
-Data type: `String`
+Data type: `Variant[String, Array[String, 1]]`
 
-table to add set to.
+table or array of tables to add the set to.
 
 Default value: `'inet-filter'`
 

--- a/spec/acceptance/all_rules_spec.rb
+++ b/spec/acceptance/all_rules_spec.rb
@@ -71,6 +71,11 @@ describe 'nftables class' do
       include nftables::rules::wireguard
       include nftables::services::dhcpv6_client
       include nftables::services::openafs_client
+      nftables::set{'my_test_set':
+        type       => 'ipv4_addr',
+        elements   => ['192.168.0.1', '10.0.0.2'],
+        table      => ['inet-filter', 'ip-nat'],
+      }
       # nftables cannot be started in docker so replace service with a validation only.
       systemd::dropin_file{"zzz_docker_nft.conf":
         ensure  => present,

--- a/spec/defines/set_spec.rb
+++ b/spec/defines/set_spec.rb
@@ -154,6 +154,61 @@ describe 'nftables::set' do
           )
         }
       end
+
+      describe 'default table can be changed' do
+        let(:params) do
+          {
+            type: 'ipv6_addr',
+            elements: ['2001:1458::1', '2001:1458:1::2'],
+            table: 'ip-nat'
+          }
+        end
+
+        it { is_expected.to compile }
+        it {
+          is_expected.to contain_concat__fragment('nftables-ip-nat-set-my_set').with(
+            target:  'nftables-ip-nat',
+            content: %r{^  set my_set \{\n    type ipv6_addr\n    elements = \{ 2001:1458::1, 2001:1458:1::2 \}\n  \}$}m,
+            order:   '10',
+          )
+        }
+      end
+
+      describe 'multiple tables no tables' do
+        let(:params) do
+          {
+            type: 'ipv6_addr',
+            elements: ['2001:1458::1', '2001:1458:1::2'],
+            table: []
+          }
+        end
+
+        it { is_expected.not_to compile }
+      end
+
+      describe 'multiple tables' do
+        let(:params) do
+          {
+            type: 'ipv6_addr',
+            elements: ['2001:1458::1', '2001:1458:1::2'],
+            table: ['inet-filter', 'ip-nat']
+          }
+        end
+
+        it { is_expected.to compile }
+        it {
+          is_expected.to contain_concat__fragment('nftables-inet-filter-set-my_set').with(
+            target:  'nftables-inet-filter',
+            content: %r{^  set my_set \{\n    type ipv6_addr\n    elements = \{ 2001:1458::1, 2001:1458:1::2 \}\n  \}$}m,
+            order:   '10',
+          )
+          is_expected.to contain_concat__fragment('nftables-ip-nat-set-my_set').with(
+            target:  'nftables-ip-nat',
+            content: %r{^  set my_set \{\n    type ipv6_addr\n    elements = \{ 2001:1458::1, 2001:1458:1::2 \}\n  \}$}m,
+            order:   '10',
+          )
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
This changeset supercharges the `table` parameter of `nftables::set` to allow passing either a `String` for a single table (to maintain backwards compatibility) or an `Array[String]`. The second option allows hence to declare the same set in several tables in one go.

I'm adding as well an extra element to the "all rules" acceptance check to make sure that it's fine to use the new functionality to declare a single set in multiple tables.

Closes #100