### PR TITLE
Use protocol number instead of label

### DIFF
--- a/manifests/rules/ospf.pp
+++ b/manifests/rules/ospf.pp
@@ -2,6 +2,6 @@
 class nftables::rules::ospf {
   nftables::rule {
     'default_in-ospf':
-      content => 'ip daddr { 224.0.0.5, 224.0.0.6 } meta l4proto ospf accept',
+      content => 'ip daddr { 224.0.0.5, 224.0.0.6 } meta l4proto 89 accept',
   }
 }

--- a/manifests/rules/ospf3.pp
+++ b/manifests/rules/ospf3.pp
@@ -2,6 +2,6 @@
 class nftables::rules::ospf3 {
   nftables::rule {
     'default_in-ospf3':
-      content => 'ip6 saddr fe80::/64 ip6 daddr { ff02::5, ff02::6 } meta l4proto ospf accept',
+      content => 'ip6 saddr fe80::/64 ip6 daddr { ff02::5, ff02::6 } meta l4proto 89 accept',
   }
 }

--- a/manifests/rules/out/ospf.pp
+++ b/manifests/rules/out/ospf.pp
@@ -2,6 +2,6 @@
 class nftables::rules::out::ospf {
   nftables::rule {
     'default_out-ospf':
-      content => 'ip daddr { 224.0.0.5, 224.0.0.6 } meta l4proto ospf accept',
+      content => 'ip daddr { 224.0.0.5, 224.0.0.6 } meta l4proto 89 accept',
   }
 }

--- a/manifests/rules/out/ospf3.pp
+++ b/manifests/rules/out/ospf3.pp
@@ -2,6 +2,6 @@
 class nftables::rules::out::ospf3 {
   nftables::rule {
     'default_out-ospf3':
-      content => 'ip6 saddr fe80::/64 ip6 daddr { ff02::5, ff02::6 } meta l4proto ospf accept',
+      content => 'ip6 saddr fe80::/64 ip6 daddr { ff02::5, ff02::6 } meta l4proto 89 accept',
   }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
The label was `ospf` and will be `ospfigp` in the future. Instead of
creating a map use the protocol number to be compatible with newer
versions.

#### This Pull Request (PR) fixes the following issues
Fixes #111 