### PR TITLE
Provide a mechanism to flush un-managed rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ Initially puppet deploys all configuration to
 If and only if successful the configuration will be copied to
 the real locations before the service is reloaded.
 
+## Un-managed rules
+
+Rules added manually by the administrator to the in-memory ruleset
+will be left untouched. However, `nftables::allow_unmanaged_rules` can
+be set to `false` to revert this behaviour and force a reload of the
+ruleset during the Puppet run if non-managed changes are detected.
+
 ## Basic types
 
 ### nftables::config

--- a/README.md
+++ b/README.md
@@ -65,10 +65,11 @@ the real locations before the service is reloaded.
 
 ## Un-managed rules
 
-Rules added manually by the administrator to the in-memory ruleset
-will be left untouched. However, `nftables::allow_unmanaged_rules` can
-be set to `false` to revert this behaviour and force a reload of the
-ruleset during the Puppet run if non-managed changes are detected.
+By default, rules added manually by the administrator to the in-memory
+ruleset will be left untouched. However,
+`nftables::purge_unmanaged_rules` can be set to `true` to revert this
+behaviour and force a reload of the ruleset during the Puppet run if
+non-managed changes are detected.
 
 ## Basic types
 

--- a/files/systemd/nft-hash-ruleset.sh
+++ b/files/systemd/nft-hash-ruleset.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# This file is Puppet managed
+
+umask 0377
+/sbin/nft -s list ruleset | /usr/bin/sha1sum > $1

--- a/files/systemd/puppet_nft.conf
+++ b/files/systemd/puppet_nft.conf
@@ -1,7 +1,0 @@
-# Puppet Deployed
-[Service]
-ExecStart=
-ExecStart=/sbin/nft -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf
-ExecReload=
-ExecReload=/sbin/nft -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf
-

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -113,7 +113,7 @@ class nftables (
   Hash $sets = {},
   String $log_prefix = '[nftables] %<chain>s %<comment>s',
   String[1] $nat_table_name = 'nat',
-  Stdlib::Unixpath $inmem_rules_hash_file = '/var/cache/nft-memhash',
+  Stdlib::Unixpath $inmem_rules_hash_file = '/run/puppet-nft-memhash',
   Variant[Boolean[false], String] $log_limit = '3/minute burst 5 packets',
   Variant[Boolean[false], Pattern[/icmp(v6|x)? type .+|tcp reset/]] $reject_with = 'icmpx type port-unreachable',
   Variant[Boolean[false], Enum['mask']] $firewalld_enable = 'mask',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,7 +44,7 @@
 #   Add default tables and chains to process NAT traffic.
 #
 # @param purge_unmanaged_rules
-#   Disallows to have in-memory rules that are not declared in Puppet
+#   Prohibits in-memory rules that are not declared in Puppet
 #   code. Setting this to true activates a check that reloads nftables
 #   if the rules in memory have been modified outwith Puppet.
 #

--- a/spec/classes/nftables_spec.rb
+++ b/spec/classes/nftables_spec.rb
@@ -78,7 +78,7 @@ describe 'nftables' do
           content: %r{^ExecReload=/sbin/nft -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf$}
         )
         is_expected.not_to contain_systemd__dropin_file('puppet_nft.conf').with(
-          content: %r{^ExecReload=.*nft-hash-ruleset.sh.*$}
+          content: %r{^ExecReload=.*nft-hash-ruleset\.sh.*$}
         )
         is_expected.not_to contain_systemd__dropin_file('puppet_nft.conf').with(
           content: %r{^ExecStartPost.*$}
@@ -235,12 +235,12 @@ describe 'nftables' do
         }
         it {
           is_expected.to contain_systemd__dropin_file('puppet_nft.conf').with(
-            content: %r{^ExecReload=/bin/bash /usr/local/sbin/nft-hash-ruleset.sh /foo/bar$}
+            content: %r{^ExecReload=/bin/bash /usr/local/sbin/nft-hash-ruleset\.sh /foo/bar$}
           )
         }
         it {
           is_expected.to contain_systemd__dropin_file('puppet_nft.conf').with(
-            content: %r{^ExecStartPost=/bin/bash /usr/local/sbin/nft-hash-ruleset.sh /foo/bar$}
+            content: %r{^ExecStartPost=/bin/bash /usr/local/sbin/nft-hash-ruleset\.sh /foo/bar$}
           )
         }
       end

--- a/spec/classes/nftables_spec.rb
+++ b/spec/classes/nftables_spec.rb
@@ -101,7 +101,7 @@ describe 'nftables' do
       it { is_expected.not_to contain_class('nftables::rules::out::all') }
       it { is_expected.not_to contain_nftables__rule('default_out-all') }
       it { is_expected.not_to contain_exec('Reload nftables if there are un-managed rules') }
-      it { is_expected.to contain_file('/var/cache/nft-memhash') }
+      it { is_expected.to contain_file('/run/puppet-nft-memhash') }
       it { is_expected.not_to contain_file('/usr/local/sbin/nft-hash-ruleset.sh') }
 
       context 'with out_all set true' do

--- a/spec/classes/nftables_spec.rb
+++ b/spec/classes/nftables_spec.rb
@@ -219,7 +219,7 @@ describe 'nftables' do
       context 'with not allowing un-managed changes' do
         let(:params) do
           {
-            'allow_unmanaged_rules' => false,
+            'purge_unmanaged_rules' => true,
             'inmem_rules_hash_file' => '/foo/bar',
           }
         end

--- a/templates/systemd/puppet_nft.conf.epp
+++ b/templates/systemd/puppet_nft.conf.epp
@@ -1,16 +1,16 @@
 <%- |
-  Boolean $allow_unmanaged,
+  Boolean $purge_unmanaged,
   Stdlib::Unixpath $hash_file,
 |-%>
 # Puppet Deployed
 [Service]
 ExecStart=
 ExecStart=/sbin/nft -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf
-<% if $allow_unmanaged == false { -%>
+<% if $purge_unmanaged { -%>
 ExecStartPost=/bin/bash /usr/local/sbin/nft-hash-ruleset.sh <%= $hash_file %>
 <% } -%>
 ExecReload=
 ExecReload=/sbin/nft -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf
-<% if $allow_unmanaged == false { -%>
+<% if $purge_unmanaged { -%>
 ExecReload=/bin/bash /usr/local/sbin/nft-hash-ruleset.sh <%= $hash_file -%>
 <% } -%>

--- a/templates/systemd/puppet_nft.conf.epp
+++ b/templates/systemd/puppet_nft.conf.epp
@@ -1,0 +1,16 @@
+<%- |
+  Boolean $allow_unmanaged,
+  Stdlib::Unixpath $hash_file,
+|-%>
+# Puppet Deployed
+[Service]
+ExecStart=
+ExecStart=/sbin/nft -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf
+<% if $allow_unmanaged == false { -%>
+ExecStartPost=/bin/bash /usr/local/sbin/nft-hash-ruleset.sh <%= $hash_file %>
+<% } -%>
+ExecReload=
+ExecReload=/sbin/nft -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf
+<% if $allow_unmanaged == false { -%>
+ExecReload=/bin/bash /usr/local/sbin/nft-hash-ruleset.sh <%= $hash_file -%>
+<% } -%>


### PR DESCRIPTION
This patchset adds a new parameter to the main class to activate a mechanism that will invoke `systemctl reload nftables` during the Puppet run if manual changes to the in-memory ruleset are detected.

To accomplish this, the systemd unit in charge of nftables is configured to write a hash of the in-memory ruleset right after starting/reloading. During the Puppet run, the hash of the current rule set is compared to the one previously stored. If the hash differs then `systemctl reload nftables` is executed to flush manual changes.

Fixes #113