### PR TITLE
DO NOT MERGE - Enable tests on 9

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -31,19 +31,22 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
       ]
     }
   ],


### PR DESCRIPTION
This is just to demonstate that CentOS 9 platform is getting old facts despite facterdb despite CentOS 9 facter 4 facts being there.

```
facter (4.2.6)
facterdb (1.12.1)
puppet (7.13.1)
```

```
 bundle exec rspec --fail-fast spec/classes/bridges_spec.rb 
No facts were found in the FacterDB for Facter v4.2.4 on {:operatingsystem=>"CentOS", :operatingsystemrelease=>"/^9/", :hardwaremodel=>"x86_64"}, using v2.4.6 instead
```
and the failure is due to the interfaces fact not being present but that's not surprising.

In principal https://github.com/voxpupuli/facterdb/blob/master/facts/4.2/centos-9-x86_64.facts is there.

