### PR TITLE
vp-puppet-lint-plugin enables param-docs already

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -5,7 +5,3 @@ spec/spec_helper.rb:
 spec/spec_helper_acceptance.rb:
   unmanaged: false
 
-Gemfile:
-  optional:
-    ':test':
-      - gem: puppet-lint-param-docs


### PR DESCRIPTION
#### Pull Request (PR) description

No need to enable puppet-lint-param-docs locally since version 3.0.0
of voxpupuli-puppet-lint-plugins enables param-docs anyway.

https://github.com/voxpupuli/voxpupuli-puppet-lint-plugins/commit/5c207d586878162218e45ce50bcfd927588796c9

