### PR TITLE
Add support for Arch Linux

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,1 +1,3 @@
---- {}
+---
+
+nftables::configuration_path: '/etc/sysconfig/nftables.conf'

--- a/data/os/Archlinux.yaml
+++ b/data/os/Archlinux.yaml
@@ -1,0 +1,6 @@
+---
+
+# firewalld is not installed by default in Arch Linux
+nftables::firewalld_enable: false
+
+nftables::configuration_path: /etc/nftables.conf

--- a/files/systemd/puppet_nft.conf
+++ b/files/systemd/puppet_nft.conf
@@ -1,8 +1,0 @@
-# Puppet Deployed
-[Service]
-RemainAfterExit=yes
-ExecStart=
-ExecStart=/sbin/nft -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf
-ExecReload=
-ExecReload=/sbin/nft -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf
-

--- a/metadata.json
+++ b/metadata.json
@@ -48,6 +48,9 @@
         "8",
         "9"
       ]
+    },
+    {
+      "operatingsystem": "Archlinux"
     }
   ],
   "requirements": [

--- a/spec/acceptance/all_rules_spec.rb
+++ b/spec/acceptance/all_rules_spec.rb
@@ -78,6 +78,14 @@ describe 'nftables class' do
         elements   => ['192.168.0.1', '10.0.0.2'],
         table      => ['inet-filter', 'ip-nat'],
       }
+      $config_path = case $facts['os']['family'] {
+        'Archlinux': {
+          '/etc/nftables.conf'
+        }
+        default: {
+          '/etc/sysconfig/nftables.conf'
+        }
+      }
       # nftables cannot be started in docker so replace service with a validation only.
       systemd::dropin_file{"zzz_docker_nft.conf":
         ensure  => present,
@@ -85,9 +93,9 @@ describe 'nftables class' do
         content => [
           "[Service]",
           "ExecStart=",
-          "ExecStart=/sbin/nft -c -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf",
+          "ExecStart=/sbin/nft -c -I /etc/nftables/puppet -f $config_path",
           "ExecReload=",
-          "ExecReload=/sbin/nft -c -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf",
+          "ExecReload=/sbin/nft -c -I /etc/nftables/puppet -f $config_path",
           "",
           ].join("\n"),
         notify  => Service["nftables"],

--- a/spec/acceptance/default_spec.rb
+++ b/spec/acceptance/default_spec.rb
@@ -11,6 +11,14 @@ describe 'nftables class' do
       class { 'nftables':
         firewalld_enable => false,
       }
+      $config_path = case $facts['os']['family'] {
+        'Archlinux': {
+          '/etc/nftables.conf'
+        }
+        default: {
+          '/etc/sysconfig/nftables.conf'
+        }
+      }
       # nftables cannot be started in docker so replace service with a validation only.
       systemd::dropin_file{"zzz_docker_nft.conf":
         ensure  => present,
@@ -18,9 +26,9 @@ describe 'nftables class' do
         content => [
           "[Service]",
           "ExecStart=",
-          "ExecStart=/sbin/nft -c -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf",
+          "ExecStart=/sbin/nft -c -I /etc/nftables/puppet -f $config_path",
           "ExecReload=",
-          "ExecReload=/sbin/nft -c -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf",
+          "ExecReload=/sbin/nft -c -I /etc/nftables/puppet -f $config_path",
           "",
           ].join("\n"),
         notify  => Service["nftables"],
@@ -58,6 +66,14 @@ describe 'nftables class' do
       nftables::rule{'default_out-junk':
         content => 'A load of junk',
       }
+      $config_path = case $facts['os']['family'] {
+        'Archlinux': {
+          '/etc/nftables.conf'
+        }
+        default: {
+          '/etc/sysconfig/nftables.conf'
+        }
+      }
       # nftables cannot be started in docker so replace service with a validation only.
       systemd::dropin_file{"zzz_docker_nft.conf":
         ensure  => present,
@@ -65,9 +81,9 @@ describe 'nftables class' do
         content => [
           "[Service]",
           "ExecStart=",
-          "ExecStart=/sbin/nft -c -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf",
+          "ExecStart=/sbin/nft -c -I /etc/nftables/puppet -f $config_path",
           "ExecReload=",
-          "ExecReload=/sbin/nft -c -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf",
+          "ExecReload=/sbin/nft -c -I /etc/nftables/puppet -f $config_path",
           "",
           ].join("\n"),
         notify  => Service["nftables"],
@@ -90,6 +106,14 @@ describe 'nftables class' do
         inet_filter => false,
         nat => false,
       }
+      $config_path = case $facts['os']['family'] {
+        'Archlinux': {
+          '/etc/nftables.conf'
+        }
+        default: {
+          '/etc/sysconfig/nftables.conf'
+        }
+      }
       # nftables cannot be started in docker so replace service with a validation only.
       systemd::dropin_file{"zzz_docker_nft.conf":
         ensure  => present,
@@ -97,9 +121,9 @@ describe 'nftables class' do
         content => [
           "[Service]",
           "ExecStart=",
-          "ExecStart=/sbin/nft -c -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf",
+          "ExecStart=/sbin/nft -c -I /etc/nftables/puppet -f $config_path",
           "ExecReload=",
-          "ExecReload=/sbin/nft -c -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf",
+          "ExecReload=/sbin/nft -c -I /etc/nftables/puppet -f $config_path",
           "",
           ].join("\n"),
         notify  => Service["nftables"],
@@ -122,6 +146,14 @@ describe 'nftables class' do
         nat => true,
         nat_table_name => 'mycustomtablename',
       }
+      $config_path = case $facts['os']['family'] {
+        'Archlinux': {
+          '/etc/nftables.conf'
+        }
+        default: {
+          '/etc/sysconfig/nftables.conf'
+        }
+      }
       # nftables cannot be started in docker so replace service with a validation only.
       systemd::dropin_file{"zzz_docker_nft.conf":
         ensure  => present,
@@ -129,9 +161,9 @@ describe 'nftables class' do
         content => [
           "[Service]",
           "ExecStart=",
-          "ExecStart=/sbin/nft -c -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf",
+          "ExecStart=/sbin/nft -c -I /etc/nftables/puppet -f $config_path",
           "ExecReload=",
-          "ExecReload=/sbin/nft -c -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf",
+          "ExecReload=/sbin/nft -c -I /etc/nftables/puppet -f $config_path",
           "",
           ].join("\n"),
         notify  => Service["nftables"],

--- a/spec/classes/nftables_spec.rb
+++ b/spec/classes/nftables_spec.rb
@@ -14,6 +14,15 @@ describe 'nftables' do
       it { is_expected.to contain_package('nftables') }
 
       it {
+        is_expected.to contain_file('/etc/nftables').with(
+          ensure: 'directory',
+          owner: 'root',
+          group: 'root',
+          mode: '0750'
+        )
+      }
+
+      it {
         expect(subject).to contain_file('/etc/nftables/puppet.nft').with(
           ensure: 'file',
           owner: 'root',
@@ -73,18 +82,33 @@ describe 'nftables' do
         )
       }
 
-      it {
-        expect(subject).to contain_systemd__dropin_file('puppet_nft.conf').with(
-          content: %r{^ExecReload=/sbin/nft -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf$}
-        )
-      }
+      if os_facts[:os]['family'] == 'Archlinux'
+        it {
+          expect(subject).to contain_systemd__dropin_file('puppet_nft.conf').with(
+            content: %r{^ExecReload=/sbin/nft -I /etc/nftables/puppet -f /etc/nftables.conf$}
+          )
+        }
 
-      it {
-        expect(subject).to contain_service('firewalld').with(
-          ensure: 'stopped',
-          enable: 'mask'
-        )
-      }
+        it {
+          expect(subject).to contain_service('firewalld').with(
+            ensure: 'stopped',
+            enable: false
+          )
+        }
+      else
+        it {
+          expect(subject).to contain_systemd__dropin_file('puppet_nft.conf').with(
+            content: %r{^ExecReload=/sbin/nft -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf$}
+          )
+        }
+
+        it {
+          expect(subject).to contain_service('firewalld').with(
+            ensure: 'stopped',
+            enable: 'mask'
+          )
+        }
+      end
 
       it { is_expected.to contain_class('nftables::inet_filter') }
       it { is_expected.to contain_class('nftables::ip_nat') }

--- a/templates/systemd/puppet_nft.conf.epp
+++ b/templates/systemd/puppet_nft.conf.epp
@@ -1,0 +1,7 @@
+# Puppet Deployed
+[Service]
+RemainAfterExit=yes
+ExecStart=
+ExecStart=/sbin/nft -I /etc/nftables/puppet -f <%= $configuration_path %>
+ExecReload=
+ExecReload=/sbin/nft -I /etc/nftables/puppet -f <%= $configuration_path %>


### PR DESCRIPTION
Arch Linux stores the configuration in a different path and does not provide firewalld without explicit installation.

This basically the same as #66 – I've reused their code since it hasn't been merged in a while.