### PR TITLE
Ensure that nftables.service remains active after it exits

### DIFF
--- a/files/systemd/puppet_nft.conf
+++ b/files/systemd/puppet_nft.conf
@@ -1,5 +1,6 @@
 # Puppet Deployed
 [Service]
+RemainAfterExit=yes
 ExecStart=
 ExecStart=/sbin/nft -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf
 ExecReload=


### PR DESCRIPTION
Some system-packages don't include it in the service-file, and we expect it.

See #124.