### PR TITLE
rspec mock systemd process on docker

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,4 +1,6 @@
 ---
+spec/spec_helper.rb:
+  unmanaged: true
 
 spec/spec_helper_acceptance.rb:
   unmanaged: false

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,6 +1,4 @@
 ---
-spec/spec_helper.rb:
-  mock_with: ':mocha'
 
 spec/spec_helper_acceptance.rb:
   unmanaged: false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,6 @@
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
 RSpec.configure do |c|
-  c.mock_with :mocha
 end
 
 # puppetlabs_spec_helper will set up coverage if the env variable is set.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,16 @@
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
 RSpec.configure do |c|
+  c.before do
+    # select the systemd service provider even when on docker
+    # https://tickets.puppetlabs.com/browse/PUP-11167
+    if defined?(facts) && %w[Archlinux RedHat].include?(facts[:os]['family'])
+      allow(Puppet::FileSystem).to receive(:exist?).and_call_original
+      allow(Puppet::FileSystem).to receive(:exist?).with('/proc/1/comm').and_return(true)
+      allow(Puppet::FileSystem).to receive(:read).and_call_original
+      allow(Puppet::FileSystem).to receive(:read).with('/proc/1/comm').and_return(['systemd'])
+    end
+  end
 end
 
 # puppetlabs_spec_helper will set up coverage if the env variable is set.

--- a/spec/unit/facter/nftables_spec.rb
+++ b/spec/unit/facter/nftables_spec.rb
@@ -5,10 +5,10 @@ require 'spec_helper'
 describe 'nftables' do
   before do
     Facter.clear
-    Process.stubs(:uid).returns(0)
-    Facter::Util::Resolution.stubs(:which).with('nft').returns('/usr/sbin/nft')
-    Facter::Core::Execution.stubs(:execute).with('/usr/sbin/nft list tables').returns(nft_tables_result)
-    Facter::Core::Execution.stubs(:execute).with('/usr/sbin/nft --version').returns(nft_version_result)
+    allow(Process).to receive(:uid).and_return(0)
+    allow(Facter::Util::Resolution).to receive(:which).with('nft').and_return('/usr/sbin/nft')
+    allow(Facter::Core::Execution).to receive(:execute).with('/usr/sbin/nft list tables').and_return(nft_tables_result)
+    allow(Facter::Core::Execution).to receive(:execute).with('/usr/sbin/nft --version').and_return(nft_version_result)
   end
 
   context 'nft present' do
@@ -25,8 +25,8 @@ describe 'nftables' do
     let(:nft_version_result) { :failed }
 
     it 'does not return a fact' do
-      Facter::Core::Execution.stubs(:execute).with('/usr/sbin/nft --version', on_fail: :failed).returns(:failed)
-      Facter::Core::Execution.stubs(:execute).with('/usr/sbin/nft list tables', on_fail: :failed).returns(:failed)
+      allow(Facter::Core::Execution).to receive(:execute).with('/usr/sbin/nft --version', onfail: :failed).and_return(:failed)
+      allow(Facter::Core::Execution).to receive(:execute).with('/usr/sbin/nft list tables', onfail: :failed).and_return(:failed)
 
       expect(Facter.fact('nftables').value).to be_nil
     end


### PR DESCRIPTION
#### Pull Request (PR) description
On docker rspec the service provider is autodetected as redhat
rather than systemd.

https://tickets.puppetlabs.com/browse/PUP-11167

That causes

```
error during compilation: Parameter enable failed on Service[firewalld]: Provider redhat must have features 'maskable' to set 'enable' to 'mask' (file: /builds/ai/it
pet-module-nftables/code/spec/fixtures/modules/nftables/manifests/init.pp, line: 186)
```

mock the systemd process so that the systemd provider is used.

Also migrate existing mocks away from deprecated mocha.
