### PR TITLE
systemctl: Use relative path

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -177,7 +177,7 @@ class nftables (
     ensure     => running,
     enable     => true,
     hasrestart => true,
-    restart    => '/usr/bin/systemctl reload nftables',
+    restart    => 'PATH=/usr/bin:/bin systemctl reload nftables',
   }
 
   systemd::dropin_file { 'puppet_nft.conf':

--- a/spec/classes/nftables_spec.rb
+++ b/spec/classes/nftables_spec.rb
@@ -85,7 +85,7 @@ describe 'nftables' do
           ensure: 'running',
           enable: true,
           hasrestart: true,
-          restart: %r{/usr/bin/systemctl reload nft.*}
+          restart: %r{PATH=/usr/bin:/bin systemctl reload nft.*}
         )
       }
 


### PR DESCRIPTION
replacement of https://github.com/voxpupuli/puppet-nftables/pull/135. it's not required to provide an absolute path. I tested this on debian and centos, works fine.

```
Info: /Stage[main]/Nftables::Inet_filter/Nftables::Chain[INPUT]/File[/etc/nftables/puppet/inet-filter-chain-INPUT.nft]: Scheduling refresh of Service[nftables]
Debug: /Stage[main]/Nftables::Inet_filter/Nftables::Chain[INPUT]/File[/etc/nftables/puppet/inet-filter-chain-INPUT.nft]: The container Nftables::Chain[INPUT] will propagate my refresh event
Debug: Nftables::Chain[INPUT]: The container Class[Nftables::Inet_filter] will propagate my refresh event
Debug: Executing: '/bin/systemctl is-active -- nftables'
Debug: Executing: '/bin/systemctl is-enabled -- nftables'
Debug: Executing: '/bin/systemctl is-active -- nftables'
Debug: Executing: '/bin/systemctl show --property=NeedDaemonReload -- nftables'
Debug: Executing: 'systemctl reload nftables'
Notice: /Service[nftables]: Triggered 'refresh' from 1 event
```