### PR TITLE
Add all nftables families as a valid noflush pattern

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -116,7 +116,7 @@ class nftables (
   Variant[Boolean[false], String] $log_limit = '3/minute burst 5 packets',
   Variant[Boolean[false], Pattern[/icmp(v6|x)? type .+|tcp reset/]] $reject_with = 'icmpx type port-unreachable',
   Variant[Boolean[false], Enum['mask']] $firewalld_enable = 'mask',
-  Optional[Array[Pattern[/^(ip|ip6|inet)-[-a-zA-Z0-9_]+$/],1]] $noflush_tables = undef,
+  Optional[Array[Pattern[/^(ip|ip6|inet|arp|bridge|netdev)-[-a-zA-Z0-9_]+$/],1]] $noflush_tables = undef,
   Stdlib::Unixpath $echo,
   Stdlib::Unixpath $configuration_path,
   Stdlib::Unixpath $nft_path,


### PR DESCRIPTION
#### Pull Request (PR) description

Nftables has a bridge family ([Bridge filtering](https://wiki.nftables.org/wiki-nftables/index.php/Bridge_filtering)) that replaces ebtables functionality.

In some case, it might be useful to avoid flushing rules defined in the associated table. However, this is not possible at the moment as the regular expression doesn't match the name.

This patch extends the regular expression defining the `noflush_tables` parameter type to accept all possible families supported by nftables as per: https://wiki.nftables.org/wiki-nftables/index.php/Nftables_families

#### This Pull Request (PR) fixes the following issues

N/A
