### PR TITLE
Allow netdev as table family in defined type nftables::chain

### DIFF
--- a/manifests/chain.pp
+++ b/manifests/chain.pp
@@ -1,7 +1,7 @@
 # manage a chain
 define nftables::chain (
   # lint:ignore:parameter_documentation
-  Pattern[/^(ip|ip6|inet)-[a-zA-Z0-9_]+$/] $table = 'inet-filter',
+  Pattern[/^(ip|ip6|inet|netdev)-[a-zA-Z0-9_]+$/] $table = 'inet-filter',
   Pattern[/^[a-zA-Z0-9_]+$/] $chain = $title,
   Optional[Pattern[/^\d\d-[a-zA-Z0-9_]+$/]] $inject = undef,
   Optional[String] $inject_iif = undef,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Allow netdev as table family in defined type nftables::chain
Hi all, we would like to use this module in combination with the netdev table family type. 

Are there any objections?

#### This Pull Request (PR) fixes the following issues
n/a.
