### PR TITLE
Align filemode on RedHat to distro default

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,3 +1,3 @@
 ---
-
+nftables::default_config_mode: '0640'
 nftables::configuration_path: '/etc/sysconfig/nftables.conf'

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,3 +1,4 @@
 ---
 nftables::nft_path: /usr/sbin/nft
 nftables::echo: /usr/bin/echo
+nftables::default_config_mode: '0600'

--- a/manifests/chain.pp
+++ b/manifests/chain.pp
@@ -15,7 +15,7 @@ define nftables::chain (
       path           => "/etc/nftables/puppet-preflight/${table}-chain-${chain}.nft",
       owner          => root,
       group          => root,
-      mode           => '0640',
+      mode           => $nftables::default_config_mode,
       ensure_newline => true,
       require        => Package['nftables'],
   } ~> Exec['nft validate'] -> file {
@@ -24,7 +24,7 @@ define nftables::chain (
       source => "/etc/nftables/puppet-preflight/${table}-chain-${chain}.nft",
       owner  => root,
       group  => root,
-      mode   => '0640',
+      mode   => $nftables::default_config_mode,
   } ~> Service['nftables']
 
   concat::fragment {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,14 +19,14 @@ define nftables::config (
       ensure_newline => true,
       owner          => root,
       group          => root,
-      mode           => '0640',
+      mode           => $nftables::default_config_mode,
   } ~> Exec['nft validate'] -> file {
     "/etc/nftables/puppet/${prefix}${name}.nft":
       ensure => file,
       source => "/etc/nftables/puppet-preflight/${prefix}${name}.nft",
       owner  => root,
       group  => root,
-      mode   => '0640',
+      mode   => $nftables::default_config_mode,
   } ~> Service['nftables']
 
   $data = split($name, '-')

--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -30,14 +30,14 @@ define nftables::file (
     ensure  => file,
     owner   => root,
     group   => root,
-    mode    => '0640',
+    mode    => $nftables::default_config_mode,
     content => $content,
     source  => $source,
   } ~> Exec['nft validate'] -> file { "/etc/nftables/puppet/${prefix}${label}.nft":
     ensure  => file,
     owner   => root,
     group   => root,
-    mode    => '0640',
+    mode    => $nftables::default_config_mode,
     content => $content,
     source  => $source,
   } ~> Service['nftables']

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -96,6 +96,10 @@
 # @param echo
 #   Path to the echo binary
 #
+# @param default_config_mode
+#   The default file & dir mode for configuration files and directories. The
+#   default varies depending on the system, and is set in the module's data.
+#
 class nftables (
   Boolean $in_ssh = true,
   Boolean $in_icmp = true,
@@ -120,6 +124,7 @@ class nftables (
   Stdlib::Unixpath $echo,
   Stdlib::Unixpath $configuration_path,
   Stdlib::Unixpath $nft_path,
+  Stdlib::Filemode $default_config_mode,
 ) {
   package { 'nftables':
     ensure => installed,
@@ -132,13 +137,13 @@ class nftables (
     default:
       owner => 'root',
       group => 'root',
-      mode  => '0640';
+      mode  => $default_config_mode;
     '/etc/nftables':
       ensure => directory,
-      mode   => '0750';
+      mode   => $default_config_mode;
     '/etc/nftables/puppet-preflight':
       ensure  => directory,
-      mode    => '0750',
+      mode    => $default_config_mode,
       purge   => true,
       force   => true,
       recurse => true;
@@ -158,7 +163,7 @@ class nftables (
     default:
       owner => 'root',
       group => 'root',
-      mode  => '0640';
+      mode  => $default_config_mode;
     '/etc/nftables/puppet.nft':
       ensure  => file,
       content => epp('nftables/config/puppet.nft.epp', {
@@ -169,7 +174,7 @@ class nftables (
       );
     '/etc/nftables/puppet':
       ensure  => directory,
-      mode    => '0750',
+      mode    => $default_config_mode,
       purge   => true,
       force   => true,
       recurse => true;

--- a/spec/classes/dnat4_spec.rb
+++ b/spec/classes/dnat4_spec.rb
@@ -9,6 +9,13 @@ describe 'nftables' do
     context "on #{os}" do
       let(:facts) { os_facts }
 
+      nft_mode = case os_facts[:os]['family']
+                 when 'RedHat'
+                   '0600'
+                 else
+                   '0640'
+                 end
+
       context 'with dnat' do
         let(:pre_condition) do
           '
@@ -57,7 +64,7 @@ describe 'nftables' do
             path: '/etc/nftables/puppet-preflight/inet-filter-chain-default_fwd.nft',
             owner: 'root',
             group: 'root',
-            mode: '0640',
+            mode: nft_mode,
             ensure_newline: true
           )
         }
@@ -139,7 +146,7 @@ describe 'nftables' do
             path: '/etc/nftables/puppet-preflight/ip-nat-chain-PREROUTING.nft',
             owner: 'root',
             group: 'root',
-            mode: '0640',
+            mode: nft_mode,
             ensure_newline: true
           )
         }

--- a/spec/classes/inet_filter_spec.rb
+++ b/spec/classes/inet_filter_spec.rb
@@ -9,7 +9,12 @@ describe 'nftables' do
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      it { is_expected.to compile }
+      nft_mode = case os_facts[:os]['family']
+                 when 'RedHat'
+                   '0600'
+                 else
+                   '0640'
+                 end
 
       it {
         expect(subject).to contain_concat('nftables-inet-filter').with(
@@ -17,7 +22,7 @@ describe 'nftables' do
           ensure: 'present',
           owner: 'root',
           group: 'root',
-          mode: '0640'
+          mode: nft_mode
         )
       }
 
@@ -50,7 +55,7 @@ describe 'nftables' do
             path: '/etc/nftables/puppet-preflight/inet-filter-chain-INPUT.nft',
             owner: 'root',
             group: 'root',
-            mode: '0640',
+            mode: nft_mode,
             ensure_newline: true
           )
         }
@@ -132,7 +137,7 @@ describe 'nftables' do
             path: '/etc/nftables/puppet-preflight/inet-filter-chain-default_in.nft',
             owner: 'root',
             group: 'root',
-            mode: '0640',
+            mode: nft_mode,
             ensure_newline: true
           )
         }
@@ -172,7 +177,7 @@ describe 'nftables' do
             path: '/etc/nftables/puppet-preflight/inet-filter-chain-OUTPUT.nft',
             owner: 'root',
             group: 'root',
-            mode: '0640',
+            mode: nft_mode,
             ensure_newline: true
           )
         }
@@ -254,7 +259,7 @@ describe 'nftables' do
             path: '/etc/nftables/puppet-preflight/inet-filter-chain-default_out.nft',
             owner: 'root',
             group: 'root',
-            mode: '0640',
+            mode: nft_mode,
             ensure_newline: true
           )
         }
@@ -326,7 +331,7 @@ describe 'nftables' do
             path: '/etc/nftables/puppet-preflight/inet-filter-chain-FORWARD.nft',
             owner: 'root',
             group: 'root',
-            mode: '0640',
+            mode: nft_mode,
             ensure_newline: true
           )
         }
@@ -404,7 +409,7 @@ describe 'nftables' do
             path: '/etc/nftables/puppet-preflight/inet-filter-chain-default_fwd.nft',
             owner: 'root',
             group: 'root',
-            mode: '0640',
+            mode: nft_mode,
             ensure_newline: true
           )
         }
@@ -432,7 +437,7 @@ describe 'nftables' do
             path: '/etc/nftables/puppet-preflight/inet-filter-chain-global.nft',
             owner: 'root',
             group: 'root',
-            mode: '0640',
+            mode: nft_mode,
             ensure_newline: true
           )
         }

--- a/spec/classes/ip_nat_spec.rb
+++ b/spec/classes/ip_nat_spec.rb
@@ -9,6 +9,13 @@ describe 'nftables' do
     context "on #{os}" do
       let(:facts) { os_facts }
 
+      nft_mode = case os_facts[:os]['family']
+                 when 'RedHat'
+                   '0600'
+                 else
+                   '0640'
+                 end
+
       it { is_expected.to compile }
 
       it {
@@ -17,7 +24,7 @@ describe 'nftables' do
           ensure: 'present',
           owner: 'root',
           group: 'root',
-          mode: '0640'
+          mode: nft_mode
         )
       }
 
@@ -51,7 +58,7 @@ describe 'nftables' do
           ensure: 'present',
           owner: 'root',
           group: 'root',
-          mode: '0640'
+          mode: nft_mode
         )
       }
 
@@ -85,7 +92,7 @@ describe 'nftables' do
             path: '/etc/nftables/puppet-preflight/ip-nat-chain-PREROUTING.nft',
             owner: 'root',
             group: 'root',
-            mode: '0640',
+            mode: nft_mode,
             ensure_newline: true
           )
         }
@@ -129,7 +136,7 @@ describe 'nftables' do
             path: '/etc/nftables/puppet-preflight/ip-nat-chain-POSTROUTING.nft',
             owner: 'root',
             group: 'root',
-            mode: '0640',
+            mode: nft_mode,
             ensure_newline: true
           )
         }
@@ -173,7 +180,7 @@ describe 'nftables' do
             path: '/etc/nftables/puppet-preflight/ip6-nat-chain-PREROUTING6.nft',
             owner: 'root',
             group: 'root',
-            mode: '0640',
+            mode: nft_mode,
             ensure_newline: true
           )
         }
@@ -217,7 +224,7 @@ describe 'nftables' do
             path: '/etc/nftables/puppet-preflight/ip6-nat-chain-POSTROUTING6.nft',
             owner: 'root',
             group: 'root',
-            mode: '0640',
+            mode: nft_mode,
             ensure_newline: true
           )
         }
@@ -270,7 +277,7 @@ describe 'nftables' do
             ensure: 'present',
             owner: 'root',
             group: 'root',
-            mode: '0640'
+            mode: nft_mode
           )
         }
       end

--- a/spec/classes/masquerade_spec.rb
+++ b/spec/classes/masquerade_spec.rb
@@ -9,6 +9,13 @@ describe 'nftables' do
     context "on #{os}" do
       let(:facts) { os_facts }
 
+      nft_mode = case os_facts[:os]['family']
+                 when 'RedHat'
+                   '0600'
+                 else
+                   '0640'
+                 end
+
       context 'with masquerade' do
         let(:pre_condition) do
           '
@@ -41,7 +48,7 @@ describe 'nftables' do
             path: '/etc/nftables/puppet-preflight/ip-nat-chain-POSTROUTING.nft',
             owner: 'root',
             group: 'root',
-            mode: '0640',
+            mode: nft_mode,
             ensure_newline: true
           )
         }

--- a/spec/classes/nftables_spec.rb
+++ b/spec/classes/nftables_spec.rb
@@ -22,6 +22,13 @@ describe 'nftables' do
                      '/etc/nftables.conf'
                    end
 
+      nft_mode = case os_facts[:os]['family']
+                 when 'RedHat'
+                   '0600'
+                 else
+                   '0640'
+                 end
+
       it { is_expected.to compile.with_all_deps }
 
       it { is_expected.to contain_package('nftables') }
@@ -31,7 +38,7 @@ describe 'nftables' do
           ensure: 'directory',
           owner: 'root',
           group: 'root',
-          mode: '0750'
+          mode: nft_mode
         )
       }
 
@@ -40,7 +47,7 @@ describe 'nftables' do
           ensure: 'file',
           owner: 'root',
           group: 'root',
-          mode: '0640',
+          mode: nft_mode,
           content: %r{flush ruleset}
         )
       }
@@ -56,7 +63,7 @@ describe 'nftables' do
           ensure: 'directory',
           owner: 'root',
           group: 'root',
-          mode: '0750',
+          mode: nft_mode,
           purge: true,
           force: true,
           recurse: true
@@ -68,7 +75,7 @@ describe 'nftables' do
           ensure: 'file',
           owner: 'root',
           group: 'root',
-          mode: '0640',
+          mode: nft_mode,
           content: %r{flush ruleset}
         )
       }
@@ -84,7 +91,7 @@ describe 'nftables' do
           ensure: 'directory',
           owner: 'root',
           group: 'root',
-          mode: '0750',
+          mode: nft_mode,
           purge: true,
           force: true,
           recurse: true

--- a/spec/classes/router_spec.rb
+++ b/spec/classes/router_spec.rb
@@ -9,6 +9,13 @@ describe 'nftables' do
     context "on #{os}" do
       let(:facts) { os_facts }
 
+      nft_mode = case os_facts[:os]['family']
+                 when 'RedHat'
+                   '0600'
+                 else
+                   '0640'
+                 end
+
       context 'as router' do
         let(:pre_condition) do
           '
@@ -37,7 +44,7 @@ describe 'nftables' do
             path: '/etc/nftables/puppet-preflight/inet-filter-chain-default_fwd.nft',
             owner: 'root',
             group: 'root',
-            mode: '0640',
+            mode: nft_mode,
             ensure_newline: true
           )
         }
@@ -79,7 +86,7 @@ describe 'nftables' do
             path: '/etc/nftables/puppet-preflight/ip-nat-chain-PREROUTING.nft',
             owner: 'root',
             group: 'root',
-            mode: '0640',
+            mode: nft_mode,
             ensure_newline: true
           )
         }
@@ -121,7 +128,7 @@ describe 'nftables' do
             path: '/etc/nftables/puppet-preflight/ip-nat-chain-POSTROUTING.nft',
             owner: 'root',
             group: 'root',
-            mode: '0640',
+            mode: nft_mode,
             ensure_newline: true
           )
         }

--- a/spec/classes/snat4_spec.rb
+++ b/spec/classes/snat4_spec.rb
@@ -9,6 +9,13 @@ describe 'nftables' do
     context "on #{os}" do
       let(:facts) { os_facts }
 
+      nft_mode = case os_facts[:os]['family']
+                 when 'RedHat'
+                   '0600'
+                 else
+                   '0640'
+                 end
+
       context 'with snat4' do
         let(:pre_condition) do
           '
@@ -42,7 +49,7 @@ describe 'nftables' do
             path: '/etc/nftables/puppet-preflight/ip-nat-chain-POSTROUTING.nft',
             owner: 'root',
             group: 'root',
-            mode: '0640',
+            mode: nft_mode,
             ensure_newline: true
           )
         }

--- a/spec/defines/chain_spec.rb
+++ b/spec/defines/chain_spec.rb
@@ -12,6 +12,13 @@ describe 'nftables::chain' do
         facts
       end
 
+      nft_mode = case facts[:os]['family']
+                 when 'RedHat'
+                   '0600'
+                 else
+                   '0640'
+                 end
+
       it { is_expected.to compile }
 
       it { is_expected.to contain_concat('nftables-inet-filter-chain-MYCHAIN').that_notifies('Exec[nft validate]') }
@@ -23,7 +30,7 @@ describe 'nftables::chain' do
           path: '/etc/nftables/puppet-preflight/inet-filter-chain-MYCHAIN.nft',
           owner: 'root',
           group: 'root',
-          mode: '0640',
+          mode: nft_mode,
           ensure_newline: true
         )
       }
@@ -32,7 +39,7 @@ describe 'nftables::chain' do
         expect(subject).to contain_file('/etc/nftables/puppet/inet-filter-chain-MYCHAIN.nft').with(
           ensure: 'file',
           source: '/etc/nftables/puppet-preflight/inet-filter-chain-MYCHAIN.nft',
-          mode: '0640',
+          mode: nft_mode,
           owner: 'root',
           group: 'root'
         )
@@ -66,7 +73,7 @@ describe 'nftables::chain' do
             path: '/etc/nftables/puppet-preflight/ip6-foo-chain-MYCHAIN.nft',
             owner: 'root',
             group: 'root',
-            mode: '0640',
+            mode: nft_mode,
             ensure_newline: true
           )
         }
@@ -75,7 +82,7 @@ describe 'nftables::chain' do
           expect(subject).to contain_file('/etc/nftables/puppet/ip6-foo-chain-MYCHAIN.nft').with(
             ensure: 'file',
             source: '/etc/nftables/puppet-preflight/ip6-foo-chain-MYCHAIN.nft',
-            mode: '0640',
+            mode: nft_mode,
             owner: 'root',
             group: 'root'
           )

--- a/spec/defines/config_spec.rb
+++ b/spec/defines/config_spec.rb
@@ -12,6 +12,13 @@ describe 'nftables::config' do
         facts
       end
 
+      nft_mode = case facts[:os]['family']
+                 when 'RedHat'
+                   '0600'
+                 else
+                   '0640'
+                 end
+
       context 'with source and content both unset' do
         it { is_expected.to compile }
         it { is_expected.to contain_concat('nftables-FOO-BAR') }
@@ -20,7 +27,7 @@ describe 'nftables::config' do
           expect(subject).to contain_concat('nftables-FOO-BAR').with(
             path: '/etc/nftables/puppet-preflight/custom-FOO-BAR.nft',
             ensure_newline: true,
-            mode: '0640'
+            mode: nft_mode
           )
         }
 
@@ -30,7 +37,7 @@ describe 'nftables::config' do
           expect(subject).to contain_file('/etc/nftables/puppet/custom-FOO-BAR.nft').with(
             ensure: 'file',
             source: '/etc/nftables/puppet-preflight/custom-FOO-BAR.nft',
-            mode: '0640'
+            mode: nft_mode
           )
         }
 
@@ -86,7 +93,7 @@ describe 'nftables::config' do
           expect(subject).to contain_concat('nftables-FOO-BAR').with(
             path: '/etc/nftables/puppet-preflight/custom-FOO-BAR.nft',
             ensure_newline: true,
-            mode: '0640'
+            mode: nft_mode
           )
         }
 
@@ -96,7 +103,7 @@ describe 'nftables::config' do
           expect(subject).to contain_file('/etc/nftables/puppet/custom-FOO-BAR.nft').with(
             ensure: 'file',
             source: '/etc/nftables/puppet-preflight/custom-FOO-BAR.nft',
-            mode: '0640'
+            mode: nft_mode
           )
         }
 


### PR DESCRIPTION
The RPM acutally ships the configuration and directory with 0600/0700 while this module sets the mode to 0640/0750.

However, this has the drawback that on new nftables RPM versions, we are setting it back to the modules mode and triggering an nft validate.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
