### PR TITLE
Declare AlmaLinux8 and AlmaLinux9 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -29,6 +29,13 @@
   ],
   "operatingsystem_support": [
     {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
+    {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "8",


### PR DESCRIPTION
As RHEL8 and RHEL9 are declared as supported this module should work fine also on Almalinux8 and Almalinux9.

FacterDB is Almalinux-capable.