### PR TITLE
README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,27 @@
 
 This module manages an opinionated nftables configuration.
 
-By default it sets up a firewall that drops every incoming
-and outgoing connection.
+By default it sets up a firewall that drops every connection, except
+outbound ICMP, DNS, NTP, HTTP, and HTTPS, and inbound ICMP and SSH
+traffic:
 
-It only allows outgoing dns, ntp and web and ingoing ssh
-traffic, although this can be overridden using parameters.
+    include nftables
 
-The config file has a inet filter and a ip nat table setup.
+This can be overridden using parameters, for example, this allows all
+outbound traffic:
 
-Additionally, the module comes with a basic infrastructure
-to hook into different places.
+    class { 'nftables':
+        out_all => true,
+    }
+
+There are also pre-built rules for specific services, for example this
+will allow a web server to serve traffic over HTTPS:
+
+    include nftables
+    include nftables::rules::https
+
+Note that the module conflicts with the `firewalld` system and will
+stop it in Puppet runs.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ this module. Look at `nftables::inet_filter` for inspiration.
 Initially puppet deploys all configuration to
 `/etc/nftables/puppet-preflight/` and
 `/etc/nftables/puppet-preflight.nft`. This is validated with
-`nfc -c -L /etc/nftables/puppet-preflight/ -f /etc/nftables/puppet-preflight.nft`.
+`nft -c -I /etc/nftables/puppet-preflight/ -f /etc/nftables/puppet-preflight.nft`.
 If and only if successful the configuration will be copied to
 the real locations before the service is reloaded.
 

--- a/README.md
+++ b/README.md
@@ -37,17 +37,17 @@ by that module go into `files/config/puppet` and will also
 be purged if not managed anymore.
 
 The main configuration file includes dedicated files for
-the filter and nat tables, as well as processes any
+the filter and NAT tables, as well as processes any
 `custom-*.nft` files before hand.
 
 The filter and NAT tables both have all the master chains
-(INPUT, OUTPUT, FORWARD in case of filter and PREROUTING
-and POSTROUTING in case of NAT) configured, to which you
+(`INPUT`, `OUTPUT`, `FORWARD` in case of filter and `PREROUTING`
+and `POSTROUTING` in case of NAT) configured, to which you
 can hook in your own chains that can contain specific
 rules.
 
 All filter masterchains drop by default.
-By default we have a set of default_MASTERCHAIN chains
+By default we have a set of `default_MASTERCHAIN` chains
 configured to which you can easily add your custom rules.
 
 For specific needs you can add your own chain.
@@ -55,15 +55,14 @@ For specific needs you can add your own chain.
 There is a global chain, that defines the default behavior
 for all masterchains. This chain is empty by default.
 
-INPUT and OUTPUT to the loopback device is allowed by
+`INPUT` and `OUTPUT` to the loopback device is allowed by
 default, though you could restrict it later.
 
 On the other hand, if you don't want any of the default tables, chains
 and rules created by the module, you can set `nftables::inet_filter`
 and/or `nftables::nat` to `false` and build your whole nftables
 configuration from scratch by using the building blocks provided by
-this module. Looking at `nftables::inet_filter` for inspiration might
-be a good idea.
+this module. Look at `nftables::inet_filter` for inspiration.
 
 ## Rules Validation
 


### PR DESCRIPTION
I couldn't figure out how to use this module when I looked at the
README. It was quickly going into pretty arcane stuff like "inet
filter" and "ip nat table" which might make sense for the module
authors or people used to nftables/iptables, but are pretty
implementation specific when coming from another networking
background.

Instead, we just explain more clearly what the module does, and
how. We also provide *more* examples, including some that might seem
obvious ("you need to include nftables first") but were not obvious to
me at all.

I also add a warning about firewalld being stopped which seems
important as well.

Closes: #158
