### PR TITLE
Increased puppet/systemd upper limit to < 6.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 2.0.0 < 5.0.0"
+      "version_requirement": ">= 2.0.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
Increased puppet/systemd upper limit to < 6.0.0

Note that Metadata still shows `"version": "3.0.1-rc0"`, so the current master branch does not reflect the latest forge release
