### PR TITLE
Add missing unit string for timeout,gc-interval

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,6 +101,10 @@
 #   default varies depending on the system, and is set in the module's data.
 #
 class nftables (
+  Stdlib::Unixpath $echo,
+  Stdlib::Unixpath $configuration_path,
+  Stdlib::Unixpath $nft_path,
+  Stdlib::Filemode $default_config_mode,
   Boolean $in_ssh = true,
   Boolean $in_icmp = true,
   Boolean $out_ntp = true,
@@ -121,10 +125,6 @@ class nftables (
   Variant[Boolean[false], Pattern[/icmp(v6|x)? type .+|tcp reset/]] $reject_with = 'icmpx type port-unreachable',
   Variant[Boolean[false], Enum['mask']] $firewalld_enable = 'mask',
   Optional[Array[Pattern[/^(ip|ip6|inet|arp|bridge|netdev)-[-a-zA-Z0-9_]+$/],1]] $noflush_tables = undef,
-  Stdlib::Unixpath $echo,
-  Stdlib::Unixpath $configuration_path,
-  Stdlib::Unixpath $nft_path,
-  Stdlib::Filemode $default_config_mode,
 ) {
   package { 'nftables':
     ensure => installed,

--- a/templates/set.epp
+++ b/templates/set.epp
@@ -14,10 +14,10 @@
     flags <%= $flags.join(', ') %>
     <%- } -%>
     <%- if $timeout { -%>
-    timeout <%= $timeout %>
+    timeout <%= $timeout %>s
     <%- } -%>
     <%- if $gc_interval { -%>
-    gc-interval <%= $gc_interval %>
+    gc-interval <%= $gc_interval %>s
     <%- } -%>
     <%- if $elements and length($elements) > 0 { -%>
     elements = { <%= $elements.join(', ') %> }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Add unit string ("s")  for `timeout` and `gc-interval`  in set template.

#### This Pull Request (PR) fixes the following issues
Fixes #184
