### PR TITLE
nftables::simplerule::dport - takes port ranges as part of the array

### DIFF
--- a/types/port.pp
+++ b/types/port.pp
@@ -1,7 +1,7 @@
 # @summary
 #   Represents a port expression to be used within a rule.
 type Nftables::Port = Variant[
-  Array[Stdlib::Port, 1],
+  Array[Variant[Nftables::Port::Range, Stdlib::Port], 1],
   Stdlib::Port,
   Nftables::Port::Range,
 ]


### PR DESCRIPTION
#### Pull Request (PR) description

Allows nftables::simplerule's dport to accept arrays of both ports and port ranges, and not just one or the other.

#### This Pull Request (PR) fixes the following issues

Fixes #188
