### PR TITLE
Inline a file instead of using a source

### DIFF
--- a/files/config/puppet-inet-filter.nft
+++ b/files/config/puppet-inet-filter.nft
@@ -1,1 +1,0 @@
-  include "inet-filter-chain-*.nft"

--- a/manifests/inet_filter.pp
+++ b/manifests/inet_filter.pp
@@ -9,8 +9,8 @@ class nftables::inet_filter inherits nftables {
 
   nftables::config {
     'inet-filter':
-      prefix => '',
-      source => 'puppet:///modules/nftables/config/puppet-inet-filter.nft';
+      prefix  => '',
+      content => "  include \"inet-filter-chain-*.nft\"\n";
   }
 
   nftables::chain {


### PR DESCRIPTION
This file contains just a single file, so it's faster to include it in the catalog. It also means a cached catalog if the puppetserver is unavailable.