### PR TITLE
Rewrite mdns rules to limit to multicast and allow IPv6

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -657,6 +657,29 @@ Default value: `[389, 636]`
 
 allow incoming multicast DNS
 
+#### Parameters
+
+The following parameters are available in the `nftables::rules::mdns` class:
+
+* [`ipv4`](#-nftables--rules--mdns--ipv4)
+* [`ipv6`](#-nftables--rules--mdns--ipv6)
+
+##### <a name="-nftables--rules--mdns--ipv4"></a>`ipv4`
+
+Data type: `Boolean`
+
+Allow mdns over IPv4
+
+Default value: `true`
+
+##### <a name="-nftables--rules--mdns--ipv6"></a>`ipv6`
+
+Data type: `Boolean`
+
+Allow mdns over IPv6
+
+Default value: `true`
+
 ### <a name="nftables--rules--multicast"></a>`nftables::rules::multicast`
 
 allow incoming multicast traffic

--- a/manifests/rules/mdns.pp
+++ b/manifests/rules/mdns.pp
@@ -1,11 +1,22 @@
 #
 # @summary allow incoming multicast DNS
 #
-class nftables::rules::mdns {
-  nftables::rule { 'default_in-mdns1':
-    content => 'ip daddr 224.0.0.251 accept',
+# @param ipv4
+#   Allow mdns over IPv4
+# @param ipv6
+#   Allow mdns over IPv6
+class nftables::rules::mdns (
+  Boolean $ipv4 = true,
+  Boolean $ipv6 = true,
+) {
+  if $ipv4 {
+    nftables::rule { 'default_in-mdns_v4':
+      content => 'ip daddr 224.0.0.251 udp dport 5353 accept',
+    }
   }
-  nftables::rule { 'default_in-mdns2':
-    content => 'udp sport 5353 udp dport 5353 accept',
+  if $ipv6 {
+    nftables::rule { 'default_in-mdns_v6':
+      content => 'ip6 daddr ff02::fb udp dport 5353 accept',
+    }
   }
 }


### PR DESCRIPTION
This limits the mdns listener to only listen on multicast addresses with port 5353. One rule for IPv4 and one for IPv6, each controllable with a parameter.

The generic 5353 to 5353 rule is dropped since it's redundant when I read [RFC6762].

[RFC6762]: https://www.rfc-editor.org/rfc/rfc6762