### PR TITLE
Workaround for Puppet classes not able to use rich data types

### DIFF
--- a/manifests/bridges.pp
+++ b/manifests/bridges.pp
@@ -2,12 +2,12 @@
 class nftables::bridges (
   # lint:ignore:parameter_documentation
   Enum['present','absent'] $ensure = 'present',
-  Regexp $bridgenames = /^br.+/
+  Pattern[/^\^.+/] $bridgenames = '^br.+',
   # lint:endignore
 ) {
   if $ensure == 'present' {
     $interfaces = keys($facts['networking']['interfaces'])
-    $bridges = $interfaces.filter |$items| { $items =~ $bridgenames }
+    $bridges = $interfaces.filter |$items| { $items =~ Regexp($bridgenames) }
 
     $bridges.each |String $bridge| {
       $bridge_rulename = regsubst($bridge, '-|:', '_', 'G')


### PR DESCRIPTION
This was previously reported in #83 and closed without resolution
I just added the class to apply on RHEL9 instances, and problem still exists in the current code

```
2023-09-24T13:51:33.970Z ERROR [qtp894367513-7039] [p.r.core] Internal Server Error: org.jruby.exceptions.RuntimeError: (PreformattedError) Evaluation Error: Class[Nftables::Bridges]['bridgenames'] contains a Regexp value. It will be converted to the String '/^br.+/'
```
```
# puppet --version
7.26.0
```

