### PR TITLE
Drop (useless?) `is_expected.to compile` examples

### DIFF
--- a/spec/classes/bridges_spec.rb
+++ b/spec/classes/bridges_spec.rb
@@ -21,7 +21,6 @@ describe 'nftables' do
           )
         end
 
-        it { is_expected.to compile }
         it { is_expected.not_to contain_nftables__rule('default_fwd-bridge_lo_lo') }
 
         it {

--- a/spec/classes/dnat4_spec.rb
+++ b/spec/classes/dnat4_spec.rb
@@ -57,8 +57,6 @@ describe 'nftables' do
           '
         end
 
-        it { is_expected.to compile }
-
         it {
           expect(subject).to contain_concat('nftables-inet-filter-chain-default_fwd').with(
             path: '/etc/nftables/puppet-preflight/inet-filter-chain-default_fwd.nft',

--- a/spec/classes/ip_nat_spec.rb
+++ b/spec/classes/ip_nat_spec.rb
@@ -16,8 +16,6 @@ describe 'nftables' do
                    '0640'
                  end
 
-      it { is_expected.to compile }
-
       it {
         expect(subject).to contain_concat('nftables-ip-nat').with(
           path: '/etc/nftables/puppet-preflight/ip-nat.nft',
@@ -268,8 +266,6 @@ describe 'nftables' do
             'nat_table_name' => 'mycustomtablename',
           }
         end
-
-        it { is_expected.to compile }
 
         it {
           expect(subject).to contain_concat('nftables-ip-mycustomtablename').with(

--- a/spec/classes/masquerade_spec.rb
+++ b/spec/classes/masquerade_spec.rb
@@ -41,8 +41,6 @@ describe 'nftables' do
           '
         end
 
-        it { is_expected.to compile }
-
         it {
           expect(subject).to contain_concat('nftables-ip-nat-chain-POSTROUTING').with(
             path: '/etc/nftables/puppet-preflight/ip-nat-chain-POSTROUTING.nft',

--- a/spec/classes/router_spec.rb
+++ b/spec/classes/router_spec.rb
@@ -37,8 +37,6 @@ describe 'nftables' do
           '
         end
 
-        it { is_expected.to compile }
-
         it {
           expect(subject).to contain_concat('nftables-inet-filter-chain-default_fwd').with(
             path: '/etc/nftables/puppet-preflight/inet-filter-chain-default_fwd.nft',

--- a/spec/classes/rules/activemq_spec.rb
+++ b/spec/classes/rules/activemq_spec.rb
@@ -8,7 +8,6 @@ describe 'nftables::rules::activemq' do
       let(:facts) { os_facts }
 
       context 'default options' do
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_in-activemq_tcp').with_content('tcp dport 61616 accept') }
         it { is_expected.to contain_nftables__rule('default_in-activemq_udp').with_content('udp dport 61616 accept') }
       end
@@ -20,7 +19,6 @@ describe 'nftables::rules::activemq' do
           }
         end
 
-        it { is_expected.to compile }
         it { is_expected.not_to contain_nftables__rule('default_in-activemq_tcp').with_content('tcp dport 61616 accept') }
         it { is_expected.to contain_nftables__rule('default_in-activemq_udp').with_content('udp dport 61616 accept') }
       end
@@ -32,7 +30,6 @@ describe 'nftables::rules::activemq' do
           }
         end
 
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_in-activemq_tcp').with_content('tcp dport 61616 accept') }
         it { is_expected.not_to contain_nftables__rule('default_in-activemq_udp').with_content('udp dport 61616 accept') }
       end

--- a/spec/classes/rules/afs3_callback_spec.rb
+++ b/spec/classes/rules/afs3_callback_spec.rb
@@ -8,7 +8,6 @@ describe 'nftables::rules::afs3_callback' do
       let(:facts) { os_facts }
 
       context 'default options' do
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_in-afs3_callback') }
         it { is_expected.to contain_nftables__rule('default_in-afs3_callback').with_content('ip saddr { 0.0.0.0/0 } udp dport 7001 accept') }
       end
@@ -20,7 +19,6 @@ describe 'nftables::rules::afs3_callback' do
           }
         end
 
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_in-afs3_callback') }
         it { is_expected.to contain_nftables__rule('default_in-afs3_callback').with_content('ip saddr { 192.168.0.0/16, 1.2.3.4 } udp dport 7001 accept') }
       end

--- a/spec/classes/rules/ceph_mon_spec.rb
+++ b/spec/classes/rules/ceph_mon_spec.rb
@@ -8,7 +8,6 @@ describe 'nftables::rules::ceph_mon' do
       let(:facts) { os_facts }
 
       context 'default options' do
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_in-ceph_mon').with_content('tcp dport {3300, 6789} accept comment "Accept Ceph MON"') }
       end
 
@@ -19,7 +18,6 @@ describe 'nftables::rules::ceph_mon' do
           }
         end
 
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_in-ceph_mon').with_content('tcp dport {3300, 6790} accept comment "Accept Ceph MON"') }
       end
     end

--- a/spec/classes/rules/ceph_spec.rb
+++ b/spec/classes/rules/ceph_spec.rb
@@ -8,7 +8,6 @@ describe 'nftables::rules::ceph' do
       let(:facts) { os_facts }
 
       context 'default options' do
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_in-ceph').with_content('tcp dport 6800-7300 accept comment "Accept Ceph OSD, MDS, MGR"') }
       end
     end

--- a/spec/classes/rules/dns_spec.rb
+++ b/spec/classes/rules/dns_spec.rb
@@ -8,7 +8,6 @@ describe 'nftables::rules::dns' do
       let(:facts) { os_facts }
 
       context 'default options' do
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_in-dns_tcp').with_content('tcp dport {53} accept') }
         it { is_expected.to contain_nftables__rule('default_in-dns_udp').with_content('udp dport {53} accept') }
       end
@@ -20,7 +19,6 @@ describe 'nftables::rules::dns' do
           }
         end
 
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_in-dns_tcp').with_content('tcp dport {55, 60} accept') }
         it { is_expected.to contain_nftables__rule('default_in-dns_udp').with_content('udp dport {55, 60} accept') }
       end

--- a/spec/classes/rules/docker_ce_spec.rb
+++ b/spec/classes/rules/docker_ce_spec.rb
@@ -11,7 +11,6 @@ describe 'nftables::rules::docker_ce' do
       let(:pre_condition) { 'include nftables' }
 
       context 'default options' do
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__chain('DOCKER') }
         it { is_expected.to contain_nftables__chain('DOCKER_ISOLATION_STAGE_1') }
         it { is_expected.to contain_nftables__chain('DOCKER_ISOLATION_STAGE_2') }
@@ -103,8 +102,6 @@ describe 'nftables::rules::docker_ce' do
           }
         end
 
-        it { is_expected.to compile }
-
         it { is_expected.to contain_nftables__chain('DOCKER') }
         it { is_expected.to contain_nftables__chain('DOCKER_ISOLATION_STAGE_1') }
         it { is_expected.to contain_nftables__chain('DOCKER_ISOLATION_STAGE_2') }
@@ -121,8 +118,6 @@ describe 'nftables::rules::docker_ce' do
             manage_docker_chains: false,
           }
         end
-
-        it { is_expected.to compile }
 
         it { is_expected.not_to contain_nftables__chain('DOCKER') }
         it { is_expected.not_to contain_nftables__chain('DOCKER_ISOLATION_STAGE_1') }
@@ -142,7 +137,6 @@ describe 'nftables::rules::docker_ce' do
           }
         end
 
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('DOCKER_ISOLATION_STAGE_1-iifname').with_content('iifname "ifdo0" oifname != "ifdo0" counter jump DOCKER_ISOLATION_STAGE_2') }
         it { is_expected.to contain_nftables__rule('DOCKER_ISOLATION_STAGE_2-drop').with_content('oifname "ifdo0" counter drop') }
         it { is_expected.to contain_nftables__rule('default_fwd-out_docker_accept').with_content('oifname "ifdo0" ct state established,related counter accept') }

--- a/spec/classes/rules/icinga2_spec.rb
+++ b/spec/classes/rules/icinga2_spec.rb
@@ -8,7 +8,6 @@ describe 'nftables::rules::icinga2' do
       let(:facts) { os_facts }
 
       context 'default options' do
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_in-icinga2').with_content('tcp dport {5665} accept') }
       end
 
@@ -19,7 +18,6 @@ describe 'nftables::rules::icinga2' do
           }
         end
 
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_in-icinga2').with_content('tcp dport {55, 60} accept') }
       end
     end

--- a/spec/classes/rules/icmp_spec.rb
+++ b/spec/classes/rules/icmp_spec.rb
@@ -8,8 +8,6 @@ describe 'nftables::rules::icmp' do
       let(:facts) { os_facts }
 
       context 'default options' do
-        it { is_expected.to compile }
-
         it {
           expect(subject).to contain_nftables__rule('default_in-accept_icmpv4').with(
             content: 'ip protocol icmp accept',
@@ -31,8 +29,6 @@ describe 'nftables::rules::icmp' do
             v4_types: ['echo-request limit rate 4/second', 'echo-reply'],
           }
         end
-
-        it { is_expected.to compile }
 
         it {
           expect(subject).to contain_nftables__rule('default_in-accept_icmpv4_echo_request').with(
@@ -63,8 +59,6 @@ describe 'nftables::rules::icmp' do
             v6_types: %w[echo-reply nd-router-advert],
           }
         end
-
-        it { is_expected.to compile }
 
         it {
           expect(subject).to contain_nftables__rule('default_in-accept_icmpv4_echo_request').with(

--- a/spec/classes/rules/nfs3_spec.rb
+++ b/spec/classes/rules/nfs3_spec.rb
@@ -8,7 +8,6 @@ describe 'nftables::rules::nfs3' do
       let(:facts) { os_facts }
 
       context 'default options' do
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_in-nfs3').with_content('meta l4proto { tcp, udp } th dport nfs accept comment "Accept NFS3"') }
       end
     end

--- a/spec/classes/rules/nfs_spec.rb
+++ b/spec/classes/rules/nfs_spec.rb
@@ -8,7 +8,6 @@ describe 'nftables::rules::nfs' do
       let(:facts) { os_facts }
 
       context 'default options' do
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_in-nfs4').with_content('tcp dport nfs accept comment "Accept NFS4"') }
       end
     end

--- a/spec/classes/rules/node_exporter_spec.rb
+++ b/spec/classes/rules/node_exporter_spec.rb
@@ -8,7 +8,6 @@ describe 'nftables::rules::node_exporter' do
       let(:facts) { os_facts }
 
       context 'default options' do
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_in-node_exporter').with_content('tcp dport 9100 accept') }
       end
 
@@ -19,7 +18,6 @@ describe 'nftables::rules::node_exporter' do
           }
         end
 
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_in-node_exporter').with_content('tcp dport 100 accept') }
 
         context 'with prometheus_server set' do

--- a/spec/classes/rules/out/ceph_client_spec.rb
+++ b/spec/classes/rules/out/ceph_client_spec.rb
@@ -8,7 +8,6 @@ describe 'nftables::rules::out::ceph_client' do
       let(:facts) { os_facts }
 
       context 'default options' do
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_out-ceph_client').with_content('tcp dport { 3300, 6789, 6800-7300 } accept comment "Accept Ceph MON, OSD, MDS, MGR"') }
       end
 
@@ -19,7 +18,6 @@ describe 'nftables::rules::out::ceph_client' do
           }
         end
 
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_out-ceph_client').with_content('tcp dport { 3300, 6790, 6800-7300 } accept comment "Accept Ceph MON, OSD, MDS, MGR"') }
       end
     end

--- a/spec/classes/rules/out/imap_spec.rb
+++ b/spec/classes/rules/out/imap_spec.rb
@@ -8,7 +8,6 @@ describe 'nftables::rules::out::imap' do
       let(:facts) { os_facts }
 
       context 'default options' do
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_out-imap').with_content('tcp dport {143, 993} accept') }
       end
     end

--- a/spec/classes/rules/out/kerberos_spec.rb
+++ b/spec/classes/rules/out/kerberos_spec.rb
@@ -8,7 +8,6 @@ describe 'nftables::rules::out::kerberos' do
       let(:facts) { os_facts }
 
       context 'default options' do
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_out-kerberos_udp').with_content('udp dport 88 accept') }
         it { is_expected.to contain_nftables__rule('default_out-kerberos_tcp').with_content('tcp dport 88 accept') }
       end

--- a/spec/classes/rules/out/nfs3_spec.rb
+++ b/spec/classes/rules/out/nfs3_spec.rb
@@ -8,7 +8,6 @@ describe 'nftables::rules::out::nfs3' do
       let(:facts) { os_facts }
 
       context 'default options' do
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_out-nfs3').with_content('meta l4proto { tcp, udp } th dport nfs accept comment "Accept NFS3"') }
       end
     end

--- a/spec/classes/rules/out/nfs_spec.rb
+++ b/spec/classes/rules/out/nfs_spec.rb
@@ -8,7 +8,6 @@ describe 'nftables::rules::out::nfs' do
       let(:facts) { os_facts }
 
       context 'default options' do
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_out-nfs4').with_content('tcp dport nfs accept comment "Accept NFS4"') }
       end
     end

--- a/spec/classes/rules/out/openafs_client_spec.rb
+++ b/spec/classes/rules/out/openafs_client_spec.rb
@@ -8,7 +8,6 @@ describe 'nftables::rules::out::openafs_client' do
       let(:facts) { os_facts }
 
       context 'default options' do
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_out-openafs_client').with_content('udp dport {7000, 7002, 7003} accept') }
       end
 
@@ -19,7 +18,6 @@ describe 'nftables::rules::out::openafs_client' do
           }
         end
 
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_out-openafs_client').with_content('udp dport {7000, 7002} accept') }
       end
     end

--- a/spec/classes/rules/out/pop3_spec.rb
+++ b/spec/classes/rules/out/pop3_spec.rb
@@ -8,7 +8,6 @@ describe 'nftables::rules::out::pop3' do
       let(:facts) { os_facts }
 
       context 'default options' do
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_out-pop3').with_content('tcp dport {110, 995} accept') }
       end
     end

--- a/spec/classes/rules/out/puppet_spec.rb
+++ b/spec/classes/rules/out/puppet_spec.rb
@@ -11,7 +11,6 @@ describe 'nftables::rules::out::puppet' do
       end
 
       context 'default options' do
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_out-puppet-0').with_content('ip daddr 1.2.3.4 tcp dport 8140 accept') }
       end
 
@@ -20,7 +19,6 @@ describe 'nftables::rules::out::puppet' do
           super().merge({ puppetserver_port: 8141 })
         end
 
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_out-puppet-0').with_content('ip daddr 1.2.3.4 tcp dport 8141 accept') }
       end
 
@@ -29,7 +27,6 @@ describe 'nftables::rules::out::puppet' do
           { puppetserver: 'fe80::1' }
         end
 
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_out-puppet-0').with_content('ip6 daddr fe80::1 tcp dport 8140 accept') }
       end
 
@@ -38,7 +35,6 @@ describe 'nftables::rules::out::puppet' do
           { puppetserver: ['fe80::1', '1.2.3.4'] }
         end
 
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_out-puppet-0').with_content('ip6 daddr fe80::1 tcp dport 8140 accept') }
         it { is_expected.to contain_nftables__rule('default_out-puppet-1').with_content('ip daddr 1.2.3.4 tcp dport 8140 accept') }
       end

--- a/spec/classes/rules/out/smtp_client_spec.rb
+++ b/spec/classes/rules/out/smtp_client_spec.rb
@@ -8,7 +8,6 @@ describe 'nftables::rules::out::smtp_client' do
       let(:facts) { os_facts }
 
       context 'default options' do
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_out-smtp_client').with_content('tcp dport {465, 587} accept') }
       end
     end

--- a/spec/classes/rules/out/smtp_spec.rb
+++ b/spec/classes/rules/out/smtp_spec.rb
@@ -8,7 +8,6 @@ describe 'nftables::rules::out::smtp' do
       let(:facts) { os_facts }
 
       context 'default options' do
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_out-smtp').with_content('tcp dport 25 accept') }
       end
     end

--- a/spec/classes/rules/qemu_spec.rb
+++ b/spec/classes/rules/qemu_spec.rb
@@ -9,8 +9,6 @@ describe 'nftables::rules::qemu' do
       let(:pre_condition) { 'include nftables' }
 
       context 'default options' do
-        it { is_expected.to compile }
-
         it {
           expect(subject).to contain_nftables__rule('default_in-qemu_udp_dns').
             with_content('iifname "virbr0" udp dport 53 accept')
@@ -91,7 +89,6 @@ describe 'nftables::rules::qemu' do
           }
         end
 
-        it { is_expected.to compile }
         it { is_expected.not_to contain_nftables__rule('default_in-qemu_udp_dns') }
         it { is_expected.not_to contain_nftables__rule('default_in-qemu_tcp_dns') }
         it { is_expected.not_to contain_nftables__rule('default_in-qemu_dhcpv4') }
@@ -111,8 +108,6 @@ describe 'nftables::rules::qemu' do
             network_v6: '20ac:cafe:1:1::/64',
           }
         end
-
-        it { is_expected.to compile }
 
         it {
           expect(subject).to contain_nftables__rule('default_fwd-qemu_oip_v4').
@@ -142,8 +137,6 @@ describe 'nftables::rules::qemu' do
           }
         end
 
-        it { is_expected.to compile }
-
         it {
           expect(subject).to contain_nftables__rule('default_fwd-qemu_iip_v4').
             with_content('iifname "vfoo0" ip saddr 192.168.122.0/24 accept')
@@ -156,8 +149,6 @@ describe 'nftables::rules::qemu' do
             network_v4: '172.16.0.0/12'
           }
         end
-
-        it { is_expected.to compile }
 
         it {
           expect(subject).to contain_nftables__rule('default_fwd-qemu_iip_v4').

--- a/spec/classes/rules/samba_spec.rb
+++ b/spec/classes/rules/samba_spec.rb
@@ -8,7 +8,6 @@ describe 'nftables::rules::samba' do
       let(:facts) { os_facts }
 
       context 'default options' do
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_in-netbios_tcp').with_content('tcp dport {139,445} accept') }
         it { is_expected.to contain_nftables__rule('default_in-netbios_udp').with_content('udp dport {137,138} accept') }
         it { is_expected.not_to contain_nftables__rule('default_in-ctdb').with_content('tcp dport 4379 accept') }
@@ -21,7 +20,6 @@ describe 'nftables::rules::samba' do
           }
         end
 
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_in-netbios_tcp').with_content('tcp dport {139,445} accept') }
         it { is_expected.to contain_nftables__rule('default_in-netbios_udp').with_content('udp dport {137,138} accept') }
         it { is_expected.to contain_nftables__rule('default_in-ctdb').with_content('tcp dport 4379 accept') }

--- a/spec/classes/rules/ssh_spec.rb
+++ b/spec/classes/rules/ssh_spec.rb
@@ -8,7 +8,6 @@ describe 'nftables::rules::ssh' do
       let(:facts) { os_facts }
 
       context 'default options' do
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_in-ssh').with_content('tcp dport {22} accept') }
       end
 
@@ -19,7 +18,6 @@ describe 'nftables::rules::ssh' do
           }
         end
 
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_in-ssh').with_content('tcp dport {55, 60} accept') }
       end
     end

--- a/spec/classes/rules/tor_spec.rb
+++ b/spec/classes/rules/tor_spec.rb
@@ -8,7 +8,6 @@ describe 'nftables::rules::tor' do
       let(:facts) { os_facts }
 
       context 'default options' do
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_in-tor').with_content('tcp dport {9001} accept') }
       end
 
@@ -19,7 +18,6 @@ describe 'nftables::rules::tor' do
           }
         end
 
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_in-tor').with_content('tcp dport {55, 60} accept') }
       end
     end

--- a/spec/classes/rules/wireguard_spec.rb
+++ b/spec/classes/rules/wireguard_spec.rb
@@ -8,7 +8,6 @@ describe 'nftables::rules::wireguard' do
       let(:facts) { os_facts }
 
       context 'default options' do
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_in-wireguard').with_content('udp dport {51820} accept') }
       end
 
@@ -19,7 +18,6 @@ describe 'nftables::rules::wireguard' do
           }
         end
 
-        it { is_expected.to compile }
         it { is_expected.to contain_nftables__rule('default_in-wireguard').with_content('udp dport {55, 60} accept') }
       end
     end

--- a/spec/classes/rules_out_dns_spec.rb
+++ b/spec/classes/rules_out_dns_spec.rb
@@ -42,8 +42,6 @@ describe 'nftables' do
           "
         end
 
-        it { is_expected.to compile }
-
         it {
           expect(subject).to contain_concat__fragment('nftables-inet-filter-chain-default_out-rule-dnsudp-0').with(
             target: 'nftables-inet-filter-chain-default_out',

--- a/spec/classes/services/dhcpv6_client_spec.rb
+++ b/spec/classes/services/dhcpv6_client_spec.rb
@@ -8,7 +8,6 @@ describe 'nftables::services::dhcpv6_client' do
       let(:facts) { os_facts }
 
       context 'normal behaviour' do
-        it { is_expected.to compile }
         it { is_expected.to contain_class('nftables::rules::dhcpv6_client') }
         it { is_expected.to contain_class('nftables::rules::out::dhcpv6_client') }
       end

--- a/spec/classes/services/openafs_client_spec.rb
+++ b/spec/classes/services/openafs_client_spec.rb
@@ -8,7 +8,6 @@ describe 'nftables::services::openafs_client' do
       let(:facts) { os_facts }
 
       context 'normal behaviour' do
-        it { is_expected.to compile }
         it { is_expected.to contain_class('nftables::rules::afs3_callback') }
         it { is_expected.to contain_class('nftables::rules::out::openafs_client') }
       end

--- a/spec/classes/snat4_spec.rb
+++ b/spec/classes/snat4_spec.rb
@@ -42,8 +42,6 @@ describe 'nftables' do
           '
         end
 
-        it { is_expected.to compile }
-
         it {
           expect(subject).to contain_concat('nftables-ip-nat-chain-POSTROUTING').with(
             path: '/etc/nftables/puppet-preflight/ip-nat-chain-POSTROUTING.nft',

--- a/spec/defines/chain_spec.rb
+++ b/spec/defines/chain_spec.rb
@@ -19,8 +19,6 @@ describe 'nftables::chain' do
                    '0640'
                  end
 
-      it { is_expected.to compile }
-
       it { is_expected.to contain_concat('nftables-inet-filter-chain-MYCHAIN').that_notifies('Exec[nft validate]') }
       it { is_expected.to contain_exec('nft validate').that_comes_before('File[/etc/nftables/puppet/inet-filter-chain-MYCHAIN.nft]') }
       it { is_expected.to contain_file('/etc/nftables/puppet/inet-filter-chain-MYCHAIN.nft').that_comes_before('Service[nftables]') }

--- a/spec/defines/config_spec.rb
+++ b/spec/defines/config_spec.rb
@@ -20,7 +20,6 @@ describe 'nftables::config' do
                  end
 
       context 'with source and content both unset' do
-        it { is_expected.to compile }
         it { is_expected.to contain_concat('nftables-FOO-BAR') }
 
         it {
@@ -86,7 +85,6 @@ describe 'nftables::config' do
           }
         end
 
-        it { is_expected.to compile }
         it { is_expected.to contain_concat('nftables-FOO-BAR') }
 
         it {

--- a/spec/defines/file_spec.rb
+++ b/spec/defines/file_spec.rb
@@ -13,7 +13,6 @@ describe 'nftables::file' do
       end
 
       context 'with source and content both unset' do
-        it { is_expected.to compile }
         it { is_expected.to contain_file('/etc/nftables/puppet-preflight/file-FOO.nft').without_source }
         it { is_expected.to contain_file('/etc/nftables/puppet-preflight/file-FOO.nft').without_content }
         it { is_expected.to contain_file('/etc/nftables/puppet/file-FOO.nft').without_source }

--- a/spec/defines/set_spec.rb
+++ b/spec/defines/set_spec.rb
@@ -18,8 +18,6 @@ describe 'nftables::set' do
           }
         end
 
-        it { is_expected.to compile }
-
         it {
           expect(subject).to contain_concat__fragment('nftables-inet-filter-set-my_set').with(
             target: 'nftables-inet-filter',
@@ -70,8 +68,6 @@ describe 'nftables::set' do
           }
         end
 
-        it { is_expected.to compile }
-
         it {
           expect(subject).to contain_concat__fragment('nftables-inet-filter-set-my_set').with(
             target: 'nftables-inet-filter',
@@ -91,8 +87,6 @@ describe 'nftables::set' do
           }
         end
 
-        it { is_expected.to compile }
-
         it {
           expect(subject).to contain_concat__fragment('nftables-inet-filter-set-my_set').with(
             target: 'nftables-inet-filter',
@@ -111,8 +105,6 @@ describe 'nftables::set' do
           }
         end
 
-        it { is_expected.to compile }
-
         it {
           expect(subject).to contain_concat__fragment('nftables-inet-filter-set-my_set').with(
             target: 'nftables-inet-filter',
@@ -128,8 +120,6 @@ describe 'nftables::set' do
             content: 'set my_set { }',
           }
         end
-
-        it { is_expected.to compile }
 
         it {
           expect(subject).to contain_concat__fragment('nftables-inet-filter-set-my_set').with(
@@ -152,8 +142,6 @@ describe 'nftables::set' do
           }
         end
 
-        it { is_expected.to compile }
-
         it {
           expect(subject).to contain_concat__fragment('nftables-inet-filter-set-my-set').with(
             target: 'nftables-inet-filter',
@@ -171,8 +159,6 @@ describe 'nftables::set' do
             table: 'ip-nat'
           }
         end
-
-        it { is_expected.to compile }
 
         it {
           expect(subject).to contain_concat__fragment('nftables-ip-nat-set-my_set').with(
@@ -203,8 +189,6 @@ describe 'nftables::set' do
             table: %w[inet-filter ip-nat]
           }
         end
-
-        it { is_expected.to compile }
 
         it {
           expect(subject).to contain_concat__fragment('nftables-inet-filter-set-my_set').with(

--- a/spec/defines/simplerule_spec.rb
+++ b/spec/defines/simplerule_spec.rb
@@ -12,8 +12,6 @@ describe 'nftables::simplerule' do
       let(:facts) { os_facts }
 
       describe 'minimum instantiation' do
-        it { is_expected.to compile }
-
         it {
           expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
             content: 'accept',
@@ -58,8 +56,6 @@ describe 'nftables::simplerule' do
           }
         end
 
-        it { is_expected.to compile }
-
         it {
           expect(subject).to contain_nftables__rule('default_out-my_big_rule').with(
             content: 'udp sport {444} udp dport {333} ip6 saddr 2001:145c::/32 ip6 daddr 2001:1458::/32 counter accept comment "this is my rule"',
@@ -77,8 +73,6 @@ describe 'nftables::simplerule' do
           }
         end
 
-        it { is_expected.to compile }
-
         it {
           expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
             content: 'tcp sport {1-2} tcp dport {333-334} accept'
@@ -95,8 +89,6 @@ describe 'nftables::simplerule' do
           }
         end
 
-        it { is_expected.to compile }
-
         it {
           expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
             content: 'tcp sport {433, 435} tcp dport {333, 335} accept'
@@ -111,8 +103,6 @@ describe 'nftables::simplerule' do
             proto: 'tcp',
           }
         end
-
-        it { is_expected.to compile }
 
         it {
           expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
@@ -129,8 +119,6 @@ describe 'nftables::simplerule' do
           }
         end
 
-        it { is_expected.to compile }
-
         it {
           expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
             content: 'ip version 4 tcp dport {333} accept'
@@ -146,8 +134,6 @@ describe 'nftables::simplerule' do
           }
         end
 
-        it { is_expected.to compile }
-
         it {
           expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
             content: 'ip6 version 6 udp dport {33} accept'
@@ -162,8 +148,6 @@ describe 'nftables::simplerule' do
             proto: 'tcp6',
           }
         end
-
-        it { is_expected.to compile }
 
         it {
           expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
@@ -181,8 +165,6 @@ describe 'nftables::simplerule' do
           }
         end
 
-        it { is_expected.to compile }
-
         it {
           expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
             content: 'tcp dport {33} ip daddr 192.168.0.1/24 accept'
@@ -196,8 +178,6 @@ describe 'nftables::simplerule' do
             daddr: '2001:1458::1',
           }
         end
-
-        it { is_expected.to compile }
 
         it {
           expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
@@ -213,8 +193,6 @@ describe 'nftables::simplerule' do
           }
         end
 
-        it { is_expected.to compile }
-
         it {
           expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
             content: 'ip6 saddr 2001:1458:0000:0000:0000:0000:0000:0003 accept'
@@ -229,8 +207,6 @@ describe 'nftables::simplerule' do
           }
         end
 
-        it { is_expected.to compile }
-
         it {
           expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
             content: 'ip saddr 172.16.1.5 accept'
@@ -244,8 +220,6 @@ describe 'nftables::simplerule' do
             daddr: '@my6_set',
           }
         end
-
-        it { is_expected.to compile }
 
         it {
           expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
@@ -262,8 +236,6 @@ describe 'nftables::simplerule' do
           }
         end
 
-        it { is_expected.to compile }
-
         it {
           expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
             content: 'ip daddr @my4_set accept'
@@ -279,8 +251,6 @@ describe 'nftables::simplerule' do
           }
         end
 
-        it { is_expected.to compile }
-
         it {
           expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
             content: 'ip6 saddr @my6_set accept'
@@ -294,8 +264,6 @@ describe 'nftables::simplerule' do
             counter: true,
           }
         end
-
-        it { is_expected.to compile }
 
         it {
           expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
@@ -313,8 +281,6 @@ describe 'nftables::simplerule' do
             action: 'continue',
           }
         end
-
-        it { is_expected.to compile }
 
         it {
           expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(


### PR DESCRIPTION
Those `is_expected.to compile` looks useless from my perspective because there are other examples checking for other things in the catalog. So we can see the catalog compilation is failed anyway.

The benefit here is to reduce the unit test suite execution time.