### PR TITLE
Additional rules for podman root containers

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -76,6 +76,11 @@ and Manager Daemons (MGR).
 * [`nftables::rules::out::tor`](#nftables--rules--out--tor): manage out tor
 * [`nftables::rules::out::whois`](#nftables--rules--out--whois): allow clients to query remote whois server
 * [`nftables::rules::out::wireguard`](#nftables--rules--out--wireguard): manage out wireguard
+* [`nftables::rules::podman`](#nftables--rules--podman): Rules for Podman, a tool for managing OCI containers and pods.
+This class defines additional forwarding rules to let root containers
+reach external networks when using Netavark (since v4.0) or CNI (deprecated).
+At the time of writing, Podman supports automatic configuration
+of firewall rules with iptables and firewalld only.
 * [`nftables::rules::puppet`](#nftables--rules--puppet): manage in puppet
 * [`nftables::rules::pxp_agent`](#nftables--rules--pxp_agent): manage in pxp-agent
 * [`nftables::rules::qemu`](#nftables--rules--qemu): Bridged network configuration for qemu/libvirt
@@ -1189,6 +1194,14 @@ Data type: `Array[Integer,1]`
 specify wireguard ports
 
 Default value: `[51820]`
+
+### <a name="nftables--rules--podman"></a>`nftables::rules::podman`
+
+Rules for Podman, a tool for managing OCI containers and pods.
+This class defines additional forwarding rules to let root containers
+reach external networks when using Netavark (since v4.0) or CNI (deprecated).
+At the time of writing, Podman supports automatic configuration
+of firewall rules with iptables and firewalld only.
 
 ### <a name="nftables--rules--puppet"></a>`nftables::rules::puppet`
 

--- a/manifests/rules/podman.pp
+++ b/manifests/rules/podman.pp
@@ -1,0 +1,17 @@
+# @summary 
+#  Rules for Podman, a tool for managing OCI containers and pods.
+#  This class defines additional forwarding rules to let root containers
+#  reach external networks when using Netavark (since v4.0) or CNI (deprecated).
+#  At the time of writing, Podman supports automatic configuration
+#  of firewall rules with iptables and firewalld only.
+#
+class nftables::rules::podman {
+  nftables::rule {
+    'default_fwd-podman_establised':
+      content => 'ip daddr 10.88.0.0/16 ct state related,established accept',
+  }
+  nftables::rule {
+    'default_fwd-podman_accept':
+      content => 'ip saddr 10.88.0.0/16 accept',
+  }
+}

--- a/spec/acceptance/all_rules_spec.rb
+++ b/spec/acceptance/all_rules_spec.rb
@@ -26,6 +26,7 @@ describe 'nftables class' do
       include nftables::rules::dhcpv6_client
       include nftables::rules::afs3_callback
       include nftables::rules::ospf
+      include nftables::rules::podman
       include nftables::rules::http
       include nftables::rules::puppet
       include nftables::rules::pxp_agent

--- a/spec/classes/rules/podman_spec.rb
+++ b/spec/classes/rules/podman_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'nftables::rules::podman' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'default options' do
+        it { is_expected.to compile }
+        it { is_expected.to contain_nftables__rule('default_fwd-podman_establised').with_content('ip daddr 10.88.0.0/16 ct state related,established accept') }
+        it { is_expected.to contain_nftables__rule('default_fwd-podman_accept').with_content('ip saddr 10.88.0.0/16 accept') }
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description

This class defines additional forwarding rules to let root containers reach external networks when using Netavark (since v4.0) or CNI (deprecated). At the time of writing, Podman supports automatic configuration of firewall rules with iptables and firewalld only.

