### PR TITLE
Support input interface specification to dns server

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -526,11 +526,22 @@ allow DHCPv6 requests in to a host
 
 manage in dns
 
+#### Examples
+
+##### Allow access to stub dns resolver from docker containers
+
+```puppet
+class { 'nftables::rules::dns':
+  iifname => ['docker0'],
+}
+```
+
 #### Parameters
 
 The following parameters are available in the `nftables::rules::dns` class:
 
 * [`ports`](#-nftables--rules--dns--ports)
+* [`iifname`](#-nftables--rules--dns--iifname)
 
 ##### <a name="-nftables--rules--dns--ports"></a>`ports`
 
@@ -539,6 +550,14 @@ Data type: `Array[Stdlib::Port,1]`
 Specify ports for dns.
 
 Default value: `[53]`
+
+##### <a name="-nftables--rules--dns--iifname"></a>`iifname`
+
+Data type: `Optional[Array[String[1],1]]`
+
+Specify input interface names.
+
+Default value: `undef`
 
 ### <a name="nftables--rules--docker_ce"></a>`nftables::rules::docker_ce`
 

--- a/manifests/rules/dns.pp
+++ b/manifests/rules/dns.pp
@@ -1,12 +1,25 @@
 # @summary manage in dns
 # @param ports Specify ports for dns.
+# @param iifname Specify input interface names.
+#
+# @example Allow access to stub dns resolver from docker containers
+#   class { 'nftables::rules::dns':
+#     iifname => ['docker0'],
+#   }
+#
 class nftables::rules::dns (
   Array[Stdlib::Port,1] $ports = [53],
+  Optional[Array[String[1],1]] $iifname = undef,
 ) {
+  $_iifname = $iifname ? {
+    Undef   => '',
+    default => "iifname {${join($iifname, ', ')}} ",
+  }
+
   nftables::rule {
     'default_in-dns_tcp':
-      content => "tcp dport {${join($ports,', ')}} accept";
+      content => "${_iifname}tcp dport {${join($ports,', ')}} accept";
     'default_in-dns_udp':
-      content => "udp dport {${join($ports,', ')}} accept";
+      content => "${_iifname}udp dport {${join($ports,', ')}} accept";
   }
 }

--- a/spec/classes/rules/dns_spec.rb
+++ b/spec/classes/rules/dns_spec.rb
@@ -24,6 +24,18 @@ describe 'nftables::rules::dns' do
         it { is_expected.to contain_nftables__rule('default_in-dns_tcp').with_content('tcp dport {55, 60} accept') }
         it { is_expected.to contain_nftables__rule('default_in-dns_udp').with_content('udp dport {55, 60} accept') }
       end
+
+      context 'with input interfaces set' do
+        let(:params) do
+          {
+            iifname: %w[docker0 eth0],
+          }
+        end
+
+        it { is_expected.to compile }
+        it { is_expected.to contain_nftables__rule('default_in-dns_tcp').with_content('iifname {docker0, eth0} tcp dport {53} accept') }
+        it { is_expected.to contain_nftables__rule('default_in-dns_udp').with_content('iifname {docker0, eth0} udp dport {53} accept') }
+      end
     end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description

Useful when you want to allow docker/podman containers access to a hosts dns stub resolver.

```puppet
class { 'nftables::rules::dns':
  iifname => ['docker0'],
}
```