### PR TITLE
rules::ospf3 & rules::out::ospf3: Allow filtering on outgoing interfaces

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1116,6 +1116,20 @@ manage out ospf
 
 manage out ospf3
 
+#### Parameters
+
+The following parameters are available in the `nftables::rules::out::ospf3` class:
+
+* [`oifname`](#-nftables--rules--out--ospf3--oifname)
+
+##### <a name="-nftables--rules--out--ospf3--oifname"></a>`oifname`
+
+Data type: `Array[String[1]]`
+
+optional list of outgoing interfaces to filter on
+
+Default value: `[]`
+
 ### <a name="nftables--rules--out--pop3"></a>`nftables::rules::out::pop3`
 
 allow outgoing pop3

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -852,6 +852,20 @@ manage in ospf
 
 manage in ospf3
 
+#### Parameters
+
+The following parameters are available in the `nftables::rules::ospf3` class:
+
+* [`iifname`](#-nftables--rules--ospf3--iifname)
+
+##### <a name="-nftables--rules--ospf3--iifname"></a>`iifname`
+
+Data type: `Array[String[1]]`
+
+optional list of incoming interfaces to allow traffic
+
+Default value: `[]`
+
 ### <a name="nftables--rules--out--active_directory"></a>`nftables::rules::out::active_directory`
 
 manage outgoing active diectory

--- a/manifests/rules/ospf3.pp
+++ b/manifests/rules/ospf3.pp
@@ -1,7 +1,18 @@
-# manage in ospf3
-class nftables::rules::ospf3 {
-  nftables::rule {
-    'default_in-ospf3':
-      content => 'ip6 saddr fe80::/64 ip6 daddr { ff02::5, ff02::6 } meta l4proto 89 accept',
+#
+# @summary manage in ospf3
+#
+# @param iifname optional list of incoming interfaces to allow traffic
+#
+class nftables::rules::ospf3 (
+  Array[String[1]] $iifname = [],
+) {
+  if empty($iifname) {
+    $_iifname = ''
+  } else {
+    $iifdata = $iifname.map |String[1] $interface| { "\"${interface}\"" }.join(', ')
+    $_iifname = "iifname { ${iifdata} } "
+  }
+  nftables::rule { 'default_in-ospf3':
+    content => "${_iifname}ip6 saddr fe80::/64 ip6 daddr { ff02::5, ff02::6 } meta l4proto 89 accept",
   }
 }

--- a/manifests/rules/out/ospf3.pp
+++ b/manifests/rules/out/ospf3.pp
@@ -1,7 +1,18 @@
-# manage out ospf3
-class nftables::rules::out::ospf3 {
-  nftables::rule {
-    'default_out-ospf3':
-      content => 'ip6 saddr fe80::/64 ip6 daddr { ff02::5, ff02::6 } meta l4proto 89 accept',
+#
+# @summary manage out ospf3
+#
+# @param oifname optional list of outgoing interfaces to filter on
+#
+class nftables::rules::out::ospf3 (
+  Array[String[1]] $oifname = [],
+) {
+  if empty($oifname) {
+    $_oifname = ''
+  } else {
+    $oifdata = $oifname.map |String[1] $interface| { "\"${interface}\"" }.join(', ')
+    $_oifname = "oifname { ${oifdata} } "
+  }
+  nftables::rule { 'default_out-ospf3':
+    content => "${_oifname}ip6 saddr fe80::/64 ip6 daddr { ff02::5, ff02::6 } meta l4proto 89 accept",
   }
 }

--- a/spec/classes/rules/ospf3_spec.rb
+++ b/spec/classes/rules/ospf3_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'nftables::rules::ospf3' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let :facts do
+        os_facts
+      end
+
+      context 'default options' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_nftables__rule('default_in-ospf3').with_content('ip6 saddr fe80::/64 ip6 daddr { ff02::5, ff02::6 } meta l4proto 89 accept') }
+      end
+
+      context 'with input interfaces set' do
+        let :params do
+          {
+            iifname: %w[docker0 eth0],
+          }
+        end
+
+        it { is_expected.to compile }
+
+        str = 'iifname { "docker0", "eth0" } ip6 saddr fe80::/64 ip6 daddr { ff02::5, ff02::6 } meta l4proto 89 accept'
+        it { is_expected.to contain_nftables__rule('default_in-ospf3').with_content(str) }
+      end
+    end
+  end
+end

--- a/spec/classes/rules/out/ospf3_spec.rb
+++ b/spec/classes/rules/out/ospf3_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'nftables::rules::out::ospf3' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let :facts do
+        os_facts
+      end
+
+      context 'default options' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_nftables__rule('default_out-ospf3').with_content('ip6 saddr fe80::/64 ip6 daddr { ff02::5, ff02::6 } meta l4proto 89 accept') }
+      end
+
+      context 'with input interfaces set' do
+        let :params do
+          {
+            oifname: %w[docker0 eth0],
+          }
+        end
+
+        it { is_expected.to compile }
+
+        str = 'oifname { "docker0", "eth0" } ip6 saddr fe80::/64 ip6 daddr { ff02::5, ff02::6 } meta l4proto 89 accept'
+        it { is_expected.to contain_nftables__rule('default_out-ospf3').with_content(str) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Also contains https://github.com/voxpupuli/puppet-nftables/pull/233