### PR TITLE
Fix: Regex for bridge names

### DIFF
--- a/manifests/bridges.pp
+++ b/manifests/bridges.pp
@@ -2,7 +2,7 @@
 class nftables::bridges (
   # lint:ignore:parameter_documentation
   Enum['present','absent'] $ensure = 'present',
-  Regexp $bridgenames = /^br.+/
+  Regexp $bridgenames = /^br\w+$/
   # lint:endignore
 ) {
   if $ensure == 'present' {


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Correction of a too general regex concerning bridge names.  
Some bridges could be tagged, for example `br123:0`, and then could be taken by the regexp, generating an invalid config and dropping error : `syntax error, unexpected colon, expecting newline or semicolon`.

#### This Pull Request (PR) fixes the following issues
n/a
