### PR TITLE
Add support Arrays of source/destination IP addresses for nftables::simplerule

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2486,7 +2486,7 @@ Default value: `[]`
 
 Represents an address expression to be used within a rule.
 
-Alias of `Variant[Stdlib::IP::Address::V6, Stdlib::IP::Address::V4, Nftables::Addr::Set]`
+Alias of `Variant[Stdlib::IP::Address::V6, Stdlib::IP::Address::V4, Nftables::Addr::Set, Array[Stdlib::IP::Address::V6], Array[Stdlib::IP::Address::V4], Array[Nftables::Addr::Set]]`
 
 ### <a name="Nftables--Addr--Set"></a>`Nftables::Addr::Set`
 

--- a/spec/defines/simplerule_spec.rb
+++ b/spec/defines/simplerule_spec.rb
@@ -208,6 +208,22 @@ describe 'nftables::simplerule' do
         }
       end
 
+      describe 'with an IPV4 array address as daddr' do
+        let(:params) do
+          {
+            daddr: ['172.16.1.5', '172.16.1.10', '172.16.1.15'],
+          }
+        end
+
+        it { is_expected.to compile }
+
+        it {
+          expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
+            content: 'ip daddr {172.16.1.5, 172.16.1.10, 172.16.1.15} accept'
+          )
+        }
+      end
+
       describe 'with an IPv6 address as daddr' do
         let(:params) do
           {
@@ -224,10 +240,10 @@ describe 'nftables::simplerule' do
         }
       end
 
-      describe 'with an IPv6 address as saddr' do
+      describe 'with an IPV6 array address as daddr' do
         let(:params) do
           {
-            saddr: '2001:1458:0000:0000:0000:0000:0000:0003',
+            daddr: ['2001:1458:0000:0000:0000:0000:0000:0003', '8896:d5d9:e6f4:dd8f:af69:f5c0:0131:264f'],
           }
         end
 
@@ -235,7 +251,73 @@ describe 'nftables::simplerule' do
 
         it {
           expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
-            content: 'ip6 saddr 2001:1458:0000:0000:0000:0000:0000:0003 accept'
+            content: 'ip6 daddr {2001:1458:0000:0000:0000:0000:0000:0003, 8896:d5d9:e6f4:dd8f:af69:f5c0:0131:264f} accept'
+          )
+        }
+      end
+
+      describe 'with a @addr IPV4 set as daddr' do
+        let(:params) do
+          {
+            daddr: '@my4_set',
+            set_type: 'ip',
+          }
+        end
+
+        it { is_expected.to compile }
+
+        it {
+          expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
+            content: 'ip daddr @my4_set accept'
+          )
+        }
+      end
+
+      describe 'with a @addr IPV4 array set as daddr' do
+        let(:params) do
+          {
+            daddr: ['@my4_1_set', '@my4_2_set'],
+            set_type: 'ip',
+          }
+        end
+
+        it { is_expected.to compile }
+
+        it {
+          expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
+            content: 'ip daddr {@my4_1_set, @my4_2_set} accept'
+          )
+        }
+      end
+
+      describe 'with an @addr IPV6 set as daddr, default set_type' do
+        let(:params) do
+          {
+            daddr: '@my6_set',
+          }
+        end
+
+        it { is_expected.to compile }
+
+        it {
+          expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
+            content: 'ip6 daddr @my6_set accept'
+          )
+        }
+      end
+
+      describe 'with an @addr IPV6 array set as daddr, default set_type' do
+        let(:params) do
+          {
+            daddr: ['@my6_1_set', '@my6_2_set'],
+          }
+        end
+
+        it { is_expected.to compile }
+
+        it {
+          expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
+            content: 'ip6 daddr {@my6_1_set, @my6_2_set} accept'
           )
         }
       end
@@ -256,10 +338,10 @@ describe 'nftables::simplerule' do
         }
       end
 
-      describe 'with an IPv6 set as daddr, default set_type' do
+      describe 'with an IPV4 array address as saddr' do
         let(:params) do
           {
-            daddr: '@my6_set',
+            saddr: ['172.16.1.5', '172.16.1.10', '172.16.1.15'],
           }
         end
 
@@ -267,15 +349,47 @@ describe 'nftables::simplerule' do
 
         it {
           expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
-            content: 'ip6 daddr @my6_set accept'
+            content: 'ip saddr {172.16.1.5, 172.16.1.10, 172.16.1.15} accept'
           )
         }
       end
 
-      describe 'with a IPv4 set as daddr' do
+      describe 'with an IPv6 address as saddr' do
         let(:params) do
           {
-            daddr: '@my4_set',
+            saddr: '2001:1458:0000:0000:0000:0000:0000:0003',
+          }
+        end
+
+        it { is_expected.to compile }
+
+        it {
+          expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
+            content: 'ip6 saddr 2001:1458:0000:0000:0000:0000:0000:0003 accept'
+          )
+        }
+      end
+
+      describe 'with an IPV6 array address as saddr' do
+        let(:params) do
+          {
+            saddr: ['2001:1458:0000:0000:0000:0000:0000:0003', '8896:d5d9:e6f4:dd8f:af69:f5c0:0131:264f'],
+          }
+        end
+
+        it { is_expected.to compile }
+
+        it {
+          expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
+            content: 'ip6 saddr {2001:1458:0000:0000:0000:0000:0000:0003, 8896:d5d9:e6f4:dd8f:af69:f5c0:0131:264f} accept'
+          )
+        }
+      end
+
+      describe 'with a @addr IPV4 set as saddr' do
+        let(:params) do
+          {
+            saddr: '@my4_set',
             set_type: 'ip',
           }
         end
@@ -284,16 +398,32 @@ describe 'nftables::simplerule' do
 
         it {
           expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
-            content: 'ip daddr @my4_set accept'
+            content: 'ip saddr @my4_set accept'
           )
         }
       end
 
-      describe 'with a IPv6 set as saddr' do
+      describe 'with a @addr IPV4 array set as saddr' do
+        let(:params) do
+          {
+            saddr: ['@my4_1_set', '@my4_2_set'],
+            set_type: 'ip',
+          }
+        end
+
+        it { is_expected.to compile }
+
+        it {
+          expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
+            content: 'ip saddr {@my4_1_set, @my4_2_set} accept'
+          )
+        }
+      end
+
+      describe 'with an @addr IPV6 set as saddr, default set_type' do
         let(:params) do
           {
             saddr: '@my6_set',
-            set_type: 'ip6',
           }
         end
 
@@ -302,6 +432,22 @@ describe 'nftables::simplerule' do
         it {
           expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
             content: 'ip6 saddr @my6_set accept'
+          )
+        }
+      end
+
+      describe 'with an @addr IPV6 array set as saddr, default set_type' do
+        let(:params) do
+          {
+            saddr: ['@my6_1_set', '@my6_2_set'],
+          }
+        end
+
+        it { is_expected.to compile }
+
+        it {
+          expect(subject).to contain_nftables__rule('default_in-my_default_rule_name').with(
+            content: 'ip6 saddr {@my6_1_set, @my6_2_set} accept'
           )
         }
       end

--- a/spec/type_aliases/nftables_addr_spec.rb
+++ b/spec/type_aliases/nftables_addr_spec.rb
@@ -8,7 +8,12 @@ describe 'Nftables::Addr' do
   it { is_expected.to allow_value('2001:1458::/32') }
   it { is_expected.to allow_value('2001:1458::3') }
   it { is_expected.to allow_value('@set_name') }
+  it { is_expected.to allow_value(['127.0.0.1']) }
+  it { is_expected.to allow_value(['172.16.1.0/24']) }
+  it { is_expected.to allow_value(['2001:1458::/32']) }
+  it { is_expected.to allow_value(['2001:1458::3']) }
+  it { is_expected.to allow_value(['@set_name']) }
+  it { is_expected.to allow_value(['@set_name', '@set_name2']) }
   it { is_expected.not_to allow_value('anything') }
   it { is_expected.not_to allow_value(43) }
-  it { is_expected.not_to allow_value(['127.0.0.1']) }
 end

--- a/templates/simplerule.epp
+++ b/templates/simplerule.epp
@@ -24,30 +24,34 @@
   $_ip_version_filter = undef
 } -%>
 <%- if $daddr {
-  if $daddr =~ Stdlib::IP::Address::V6 {
-    $_dst_hosts = "ip6 daddr ${daddr}"
-  } elsif $daddr =~ Stdlib::IP::Address::V4 {
-    $_dst_hosts = "ip daddr ${daddr}"
-  } else {
-    $_dst_hosts = $set_type ? {
-      'ip'  => "ip daddr ${daddr}",
-      'ip6' => "ip6 daddr ${daddr}",
-    }
+  $_daddr = ($daddr =~ Array) ? {
+    true    => "{${$daddr.join(', ')}}",
+    default => $daddr,
   }
+  if $daddr =~ Stdlib::IP::Address::V6 or $daddr =~ Array[Stdlib::IP::Address::V6] {
+    $_daddr_type = 'ip6'
+  } elsif $daddr =~ Stdlib::IP::Address::V4 or $daddr =~ Array[Stdlib::IP::Address::V4] {
+    $_daddr_type = 'ip'
+  } else {
+    $_daddr_type = $set_type # ip or ip6
+  }
+  $_dst_hosts = "${_daddr_type} daddr ${_daddr}"
 } else {
   $_dst_hosts = undef
 } -%>
 <%- if $saddr {
-  if $saddr =~ Stdlib::IP::Address::V6 {
-    $_src_hosts = "ip6 saddr ${saddr}"
-  } elsif $saddr =~ Stdlib::IP::Address::V4 {
-    $_src_hosts = "ip saddr ${saddr}"
-  } else {
-    $_src_hosts = $set_type ? {
-      'ip'  => "ip saddr ${saddr}",
-      'ip6' => "ip6 saddr ${saddr}",
-    }
+  $_saddr = ($saddr =~ Array) ? {
+    true    => "{${$saddr.join(', ')}}",
+    default => $saddr,
   }
+  if $saddr =~ Stdlib::IP::Address::V6 or $saddr =~ Array[Stdlib::IP::Address::V6] {
+    $_saddr_type = 'ip6'
+  } elsif $saddr =~ Stdlib::IP::Address::V4 or $saddr =~ Array[Stdlib::IP::Address::V4] {
+    $_saddr_type = 'ip'
+  } else {
+    $_saddr_type = $set_type # ip or ip6
+  }
+  $_src_hosts = "${_saddr_type} saddr ${_saddr}"
 } else {
   $_src_hosts = undef
 } -%>

--- a/types/addr.pp
+++ b/types/addr.pp
@@ -3,5 +3,8 @@
 type Nftables::Addr = Variant[
   Stdlib::IP::Address::V6,
   Stdlib::IP::Address::V4,
-  Nftables::Addr::Set
+  Nftables::Addr::Set,
+  Array[Stdlib::IP::Address::V6],
+  Array[Stdlib::IP::Address::V4],
+  Array[Nftables::Addr::Set]
 ]


### PR DESCRIPTION
#### Pull Request (PR) description

- Modify type addr : add array IPV4, IPV6 et Addr::Set
- Modify template simplerule
- Add many spec tests
- Generate REFERENCE.md
- Sort spec tests : group all daddr tests and all saddr tests : IPV4 > IPV4 array > IPV6 > IPV6 array > IPV4 (value @addr) > IPV4 array (value @addr) > IPV6  (value @addr) > IPV6 array (value @addr)

#### This Pull Request (PR) fixes the following issues

Fixes #223
