### PR TITLE
Reload nftables service if hash at last service load does not match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not affect the functionality of the module.
 
+## [Unreleased](https://github.com/voxpupuli/puppet-nftables/tree/HEAD)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-nftables/compare/v3.7.1...HEAD)
+
+**Breaking changes:**
+
+- Drop EOL CentOS 8 support [\#245](https://github.com/voxpupuli/puppet-nftables/pull/245) ([traylenator](https://github.com/traylenator))
+
+**Implemented enhancements:**
+
+- add support for conntrack helpers [\#207](https://github.com/voxpupuli/puppet-nftables/issues/207)
+- New clobber\_default\_config paramater [\#247](https://github.com/voxpupuli/puppet-nftables/pull/247) ([traylenator](https://github.com/traylenator))
+- update puppet-systemd upper bound to 8.0.0 [\#242](https://github.com/voxpupuli/puppet-nftables/pull/242) ([TheMeier](https://github.com/TheMeier))
+- rules::llmnr: Allow interface filtering [\#235](https://github.com/voxpupuli/puppet-nftables/pull/235) ([bastelfreak](https://github.com/bastelfreak))
+- rules::ospf3 & rules::out::ospf3: Allow filtering on outgoing interfaces [\#234](https://github.com/voxpupuli/puppet-nftables/pull/234) ([bastelfreak](https://github.com/bastelfreak))
+- rules::out::mdns & rules::mdns: Allow interface filtering [\#233](https://github.com/voxpupuli/puppet-nftables/pull/233) ([bastelfreak](https://github.com/bastelfreak))
+
+**Closed issues:**
+
+- Error: /Stage\[main\]/Nftables/Service\[firewalld\]/enable: change from 'true' to 'false' failed: Could not disable firewalld: [\#239](https://github.com/voxpupuli/puppet-nftables/issues/239)
+- default debian config not overwritten -\> noflush\_tables not working [\#155](https://github.com/voxpupuli/puppet-nftables/issues/155)
+
+**Merged pull requests:**
+
+- Run default destroying acceptance tests at end [\#249](https://github.com/voxpupuli/puppet-nftables/pull/249) ([traylenator](https://github.com/traylenator))
+- Accept on Debian 11 nftables::set will fail [\#246](https://github.com/voxpupuli/puppet-nftables/pull/246) ([traylenator](https://github.com/traylenator))
+
 ## [v3.7.1](https://github.com/voxpupuli/puppet-nftables/tree/v3.7.1) (2023-12-29)
 
 [Full Changelog](https://github.com/voxpupuli/puppet-nftables/compare/v3.7.0...v3.7.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,33 +4,6 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not affect the functionality of the module.
 
-## [Unreleased](https://github.com/voxpupuli/puppet-nftables/tree/HEAD)
-
-[Full Changelog](https://github.com/voxpupuli/puppet-nftables/compare/v3.7.1...HEAD)
-
-**Breaking changes:**
-
-- Drop EOL CentOS 8 support [\#245](https://github.com/voxpupuli/puppet-nftables/pull/245) ([traylenator](https://github.com/traylenator))
-
-**Implemented enhancements:**
-
-- add support for conntrack helpers [\#207](https://github.com/voxpupuli/puppet-nftables/issues/207)
-- New clobber\_default\_config paramater [\#247](https://github.com/voxpupuli/puppet-nftables/pull/247) ([traylenator](https://github.com/traylenator))
-- update puppet-systemd upper bound to 8.0.0 [\#242](https://github.com/voxpupuli/puppet-nftables/pull/242) ([TheMeier](https://github.com/TheMeier))
-- rules::llmnr: Allow interface filtering [\#235](https://github.com/voxpupuli/puppet-nftables/pull/235) ([bastelfreak](https://github.com/bastelfreak))
-- rules::ospf3 & rules::out::ospf3: Allow filtering on outgoing interfaces [\#234](https://github.com/voxpupuli/puppet-nftables/pull/234) ([bastelfreak](https://github.com/bastelfreak))
-- rules::out::mdns & rules::mdns: Allow interface filtering [\#233](https://github.com/voxpupuli/puppet-nftables/pull/233) ([bastelfreak](https://github.com/bastelfreak))
-
-**Closed issues:**
-
-- Error: /Stage\[main\]/Nftables/Service\[firewalld\]/enable: change from 'true' to 'false' failed: Could not disable firewalld: [\#239](https://github.com/voxpupuli/puppet-nftables/issues/239)
-- default debian config not overwritten -\> noflush\_tables not working [\#155](https://github.com/voxpupuli/puppet-nftables/issues/155)
-
-**Merged pull requests:**
-
-- Run default destroying acceptance tests at end [\#249](https://github.com/voxpupuli/puppet-nftables/pull/249) ([traylenator](https://github.com/traylenator))
-- Accept on Debian 11 nftables::set will fail [\#246](https://github.com/voxpupuli/puppet-nftables/pull/246) ([traylenator](https://github.com/traylenator))
-
 ## [v3.7.1](https://github.com/voxpupuli/puppet-nftables/tree/v3.7.1) (2023-12-29)
 
 [Full Changelog](https://github.com/voxpupuli/puppet-nftables/compare/v3.7.0...v3.7.1)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ Initially puppet deploys all configuration to
 If and only if successful the configuration will be copied to
 the real locations before the service is reloaded.
 
+## Un-managed rules
+
+By default, rules added manually by the administrator to the in-memory
+ruleset will be left untouched. However,
+`nftables::purge_unmanaged_rules` can be set to `true` to revert this
+behaviour and force a reload of the ruleset during the Puppet run if
+non-managed changes are detected.
+
 ## Basic types
 
 ### nftables::config

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -289,7 +289,7 @@ Data type: `Stdlib::Unixpath`
 The name of the file where the hash of the in-memory rules
 will be stored.
 
-Default value: `'/run/puppet-nft-memhash'`
+Default value: `'/var/tmp/puppet-nft-memhash'`
 
 ##### <a name="-nftables--sets"></a>`sets`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -162,6 +162,8 @@ The following parameters are available in the `nftables` class:
 * [`inet_filter`](#-nftables--inet_filter)
 * [`nat`](#-nftables--nat)
 * [`nat_table_name`](#-nftables--nat_table_name)
+* [`purge_unmanaged_rules`](#-nftables--purge_unmanaged_rules)
+* [`inmem_rules_hash_file`](#-nftables--inmem_rules_hash_file)
 * [`sets`](#-nftables--sets)
 * [`log_prefix`](#-nftables--log_prefix)
 * [`log_discarded`](#-nftables--log_discarded)
@@ -269,6 +271,25 @@ Data type: `String[1]`
 The name of the 'nat' table.
 
 Default value: `'nat'`
+
+##### <a name="-nftables--purge_unmanaged_rules"></a>`purge_unmanaged_rules`
+
+Data type: `Boolean`
+
+Prohibits in-memory rules that are not declared in Puppet
+code. Setting this to true activates a check that reloads nftables
+if the rules in memory have been modified without Puppet.
+
+Default value: `false`
+
+##### <a name="-nftables--inmem_rules_hash_file"></a>`inmem_rules_hash_file`
+
+Data type: `Stdlib::Unixpath`
+
+The name of the file where the hash of the in-memory rules
+will be stored.
+
+Default value: `'/run/puppet-nft-memhash'`
 
 ##### <a name="-nftables--sets"></a>`sets`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -235,16 +235,18 @@ class nftables (
   if $purge_unmanaged_rules {
     # Reload the nftables ruleset from the on-disk ruleset if there are differences or it is absent. -s must be used to ignore counters
     exec { 'nftables_memory_state_check':
-      command => ['echo', 'reloading_nftables'],
-      path    => $facts['path'],
-      unless  => ["test -s ${inmem_rules_hash_file} -a \"$(nft -s list ruleset | sha1sum)\" = \"$(cat ${inmem_rules_hash_file})\""],
-      notify  => Service['nftables'],
+      command  => ['echo', 'reloading_nftables'],
+      path     => $facts['path'],
+      provider => shell,
+      unless   => ["test -s ${inmem_rules_hash_file} -a \"$(nft -s list ruleset | sha1sum)\" = \"$(cat ${inmem_rules_hash_file})\""],
+      notify   => Service['nftables'],
     }
 
     # Generate nftables_hash upon any changes from the nftables service 
     exec { 'nftables_generate_hash':
-      command     => "nft -s list ruleset | sha1sum > ${inmem_rules_hash_file}",
+      command     => ["nft -s list ruleset | sha1sum > ${inmem_rules_hash_file}"],
       path        => $facts['path'],
+      provider    => shell,
       subscribe   => Service['nftables'],
       refreshonly => true,
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -233,7 +233,7 @@ class nftables (
   }
 
   if $purge_unmanaged_rules {
-    # Reload the nftables ruleset from the on-disk ruleset if there are differences or it is absent. -s must be used to ignore counters
+    # Reload nftables ruleset from disk if running state not match last service change hash, or is absent (-s required to ignore counters)
     exec { 'nftables_memory_state_check':
       command  => ['echo', 'reloading_nftables'],
       path     => $facts['path'],
@@ -242,7 +242,7 @@ class nftables (
       notify   => Service['nftables'],
     }
 
-    # Generate nftables_hash upon any changes from the nftables service 
+    # Generate nftables hash upon changes to the nftables service 
     exec { 'nftables_generate_hash':
       command     => ["nft -s list ruleset | sha1sum > ${inmem_rules_hash_file}"],
       path        => $facts['path'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -148,7 +148,7 @@ class nftables (
   Hash $sets = {},
   String $log_prefix = '[nftables] %<chain>s %<comment>s',
   String[1] $nat_table_name = 'nat',
-  Stdlib::Unixpath $inmem_rules_hash_file = '/run/puppet-nft-memhash',
+  Stdlib::Unixpath $inmem_rules_hash_file = '/var/tmp/puppet-nft-memhash',
   Boolean $log_discarded = true,
   Variant[Boolean[false], String] $log_limit = '3/minute burst 5 packets',
   Variant[Boolean[false], Pattern[/icmp(v6|x)? type .+|tcp reset/]] $reject_with = 'icmpx type port-unreachable',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,7 +48,7 @@
 #
 # @param purge_unmanaged_rules
 #   Prohibits in-memory rules that are not declared in Puppet
-#   code. Setting this to true activates a check that restarts nftables
+#   code. Setting this to true activates a check that reloads nftables
 #   if the rules in memory have been modified without Puppet.
 #
 # @param inmem_rules_hash_file

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -234,7 +234,7 @@ class nftables (
 
   if $purge_unmanaged_rules {
     # Reload the nftables ruleset from the on-disk ruleset if there are differences or it is absent. -s must be used to ignore counters
-    exec { 'nftables_running_state_check':
+    exec { 'nftables_memory_state_check':
       command => 'echo "reloading nftables"',
       path    => ['/usr/sbin', '/sbin', '/usr/bin', '/bin'],
       unless  => "/usr/bin/test -s ${inmem_rules_hash_file} -a \"$(nft -s list ruleset | sha1sum)\" = \"$(cat ${inmem_rules_hash_file})\"",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -237,12 +237,12 @@ class nftables (
     exec { 'nftables_running_state_check':
       command => 'echo "reloading nftables"',
       path    => ['/usr/sbin', '/sbin', '/usr/bin', '/bin'],
-      unless  => "/usr/bin/test -s /var/tmp/nftables_hash -a \"$(nft -s list ruleset | sha1sum)\" = \"$(cat ${inmem_rules_hash_file})\"",
+      unless  => "/usr/bin/test -s ${inmem_rules_hash_file} -a \"$(nft -s list ruleset | sha1sum)\" = \"$(cat ${inmem_rules_hash_file})\"",
       notify  => Service['nftables'],
     }
 
     # Generate nftables_hash upon any changes from the nftables service 
-    exec { 'generate_nftables_hash':
+    exec { 'nftables_generate_hash':
       command     => "nft -s list ruleset | sha1sum > ${inmem_rules_hash_file}",
       path        => ['/usr/sbin', '/sbin', '/usr/bin', '/bin'],     
       subscribe   => Service['nftables'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -235,16 +235,16 @@ class nftables (
   if $purge_unmanaged_rules {
     # Reload the nftables ruleset from the on-disk ruleset if there are differences or it is absent. -s must be used to ignore counters
     exec { 'nftables_memory_state_check':
-      command => 'echo "reloading nftables"',
-      path    => ['/usr/sbin', '/sbin', '/usr/bin', '/bin'],
-      unless  => "/usr/bin/test -s ${inmem_rules_hash_file} -a \"$(nft -s list ruleset | sha1sum)\" = \"$(cat ${inmem_rules_hash_file})\"",
+      command => ['echo', 'reloading_nftables'],
+      path    => $facts['path'],
+      unless  => ["test -s ${inmem_rules_hash_file} -a \"$(nft -s list ruleset | sha1sum)\" = \"$(cat ${inmem_rules_hash_file})\""],
       notify  => Service['nftables'],
     }
 
     # Generate nftables_hash upon any changes from the nftables service 
     exec { 'nftables_generate_hash':
       command     => "nft -s list ruleset | sha1sum > ${inmem_rules_hash_file}",
-      path        => ['/usr/sbin', '/sbin', '/usr/bin', '/bin'],     
+      path        => $facts['path'],
       subscribe   => Service['nftables'],
       refreshonly => true,
     }

--- a/spec/classes/nftables_spec.rb
+++ b/spec/classes/nftables_spec.rb
@@ -319,18 +319,20 @@ describe 'nftables' do
         end
 
         it { is_expected.not_to contain_file('/foo/bar') }
+
         it {
           is_expected.to contain_exec('nftables_memory_state_check').with(
-            command: ["echo", "reloading_nftables"],
+            command: %w[echo reloading_nftables],
             notify: 'Service[nftables]',
-            unless: ["test -s /foo/bar -a \"$(nft -s list ruleset | sha1sum)\" = \"$(cat /foo/bar)\""]
+            unless: ['test -s /foo/bar -a "$(nft -s list ruleset | sha1sum)" = "$(cat /foo/bar)"']
           )
         }
+
         it {
           is_expected.to contain_exec('nftables_generate_hash').with(
-            command: %r{^nft -s list ruleset \| sha1sum > /foo/bar$},
+            command: ['nft -s list ruleset | sha1sum > /foo/bar'],
             subscribe: 'Service[nftables]',
-            refreshonly: true,
+            refreshonly: true
           )
         }
       end

--- a/spec/classes/nftables_spec.rb
+++ b/spec/classes/nftables_spec.rb
@@ -135,7 +135,7 @@ describe 'nftables' do
       }
 
       it {
-        expect(subject).not_to contain_exec('generate_ntfables_hash')
+        expect(subject).not_to contain_exec('nftables_generate_hash')
       }
 
       it {
@@ -323,11 +323,11 @@ describe 'nftables' do
           is_expected.to contain_exec('nftables_running_state_check').with(
             command: %r{^echo "reloading nftables"$},
             notify: 'Service[nftables]',
-            unless: %r{^/usr/bin/test -s /var/tmp/nftables_hash -a "\$\(nft -s list ruleset \| sha1sum\)" = "\$\(cat /foo/bar\)"$}
+            unless: %r{^/usr/bin/test -s /foo/bar -a "\$\(nft -s list ruleset \| sha1sum\)" = "\$\(cat /foo/bar\)"$}
           )
         }
         it {
-          is_expected.to contain_exec('generate_nftables_hash').with(
+          is_expected.to contain_exec('nftables_generate_hash').with(
             command: %r{^nft -s list ruleset \| sha1sum > /foo/bar$},
             subscribe: 'Service[nftables]',
             refreshonly: true,

--- a/spec/classes/nftables_spec.rb
+++ b/spec/classes/nftables_spec.rb
@@ -131,7 +131,7 @@ describe 'nftables' do
       }
 
       it {
-        expect(subject).not_to contain_exec('nftables_running_state_check')
+        expect(subject).not_to contain_exec('nftables_memory_state_check')
       }
 
       it {
@@ -320,7 +320,7 @@ describe 'nftables' do
 
         it { is_expected.not_to contain_file('/foo/bar') }
         it {
-          is_expected.to contain_exec('nftables_running_state_check').with(
+          is_expected.to contain_exec('nftables_memory_state_check').with(
             command: %r{^echo "reloading nftables"$},
             notify: 'Service[nftables]',
             unless: %r{^/usr/bin/test -s /foo/bar -a "\$\(nft -s list ruleset \| sha1sum\)" = "\$\(cat /foo/bar\)"$}

--- a/spec/classes/nftables_spec.rb
+++ b/spec/classes/nftables_spec.rb
@@ -139,7 +139,7 @@ describe 'nftables' do
       }
 
       it {
-        expect(subject).not_to contain_file('/run/puppet-nft-memhash')
+        expect(subject).not_to contain_file('/var/tmp/puppet-nft-memhash')
       }
 
       it {
@@ -317,8 +317,6 @@ describe 'nftables' do
             'inmem_rules_hash_file' => '/foo/bar',
           }
         end
-
-        it { is_expected.not_to contain_file('/foo/bar') }
 
         it {
           is_expected.to contain_exec('nftables_memory_state_check').with(

--- a/spec/classes/nftables_spec.rb
+++ b/spec/classes/nftables_spec.rb
@@ -321,9 +321,9 @@ describe 'nftables' do
         it { is_expected.not_to contain_file('/foo/bar') }
         it {
           is_expected.to contain_exec('nftables_memory_state_check').with(
-            command: %r{^echo "reloading nftables"$},
+            command: ["echo", "reloading_nftables"],
             notify: 'Service[nftables]',
-            unless: %r{^/usr/bin/test -s /foo/bar -a "\$\(nft -s list ruleset \| sha1sum\)" = "\$\(cat /foo/bar\)"$}
+            unless: ["test -s /foo/bar -a \"$(nft -s list ruleset | sha1sum)\" = \"$(cat /foo/bar)\""]
           )
         }
         it {

--- a/spec/classes/nftables_spec.rb
+++ b/spec/classes/nftables_spec.rb
@@ -131,6 +131,18 @@ describe 'nftables' do
       }
 
       it {
+        expect(subject).not_to contain_exec('nftables_running_state_check')
+      }
+
+      it {
+        expect(subject).not_to contain_exec('generate_ntfables_hash')
+      }
+
+      it {
+        expect(subject).not_to contain_file('/run/puppet-nft-memhash')
+      }
+
+      it {
         expect(subject).to contain_exec('nft validate').with(
           refreshonly: true,
           command: %r{^#{nft_path} -I /etc/nftables/puppet-preflight -c -f /etc/nftables/puppet-preflight.nft.*}
@@ -296,6 +308,31 @@ describe 'nftables' do
         it { is_expected.to have_nftables__chain_resource_count(0) }
         it { is_expected.to have_nftables__rule_resource_count(0) }
         it { is_expected.to have_nftables__set_resource_count(0) }
+      end
+
+      context 'when purging unmanaged rules' do
+        let(:params) do
+          {
+            'purge_unmanaged_rules' => true,
+            'inmem_rules_hash_file' => '/foo/bar',
+          }
+        end
+
+        it { is_expected.not_to contain_file('/foo/bar') }
+        it {
+          is_expected.to contain_exec('nftables_running_state_check').with(
+            command: %r{^echo "reloading nftables"$},
+            notify: 'Service[nftables]',
+            unless: %r{^/usr/bin/test -s /var/tmp/nftables_hash -a "\$\(nft -s list ruleset \| sha1sum\)" = "\$\(cat /foo/bar\)"$}
+          )
+        }
+        it {
+          is_expected.to contain_exec('generate_nftables_hash').with(
+            command: %r{^nft -s list ruleset \| sha1sum > /foo/bar$},
+            subscribe: 'Service[nftables]',
+            refreshonly: true,
+          )
+        }
       end
 
       %w[ip ip6 inet arp bridge netdev].each do |family|


### PR DESCRIPTION
This is a variation on https://github.com/voxpupuli/puppet-nftables/pull/115, where I use:
- 2 execs
- no script file on disk
- no service file modifications.

Effect:

**First install:**
- after nftables is installed and configured and service started, a hash of memory state (without counters) is written to disk in the same puppet run

**Subsequent runs:**
_Hash file not present (eg deleted):_
1. nftables service is notified to reload
2. hash file is regenerated

_Hash of memory state does not match hash on disk (eg rule manually added in memory):_
1. nftables service is notified to reload
2. hash file is regenerated

_Changes invoked by Puppet to rules:_
1. hash file is regenerated (as this module already notifies the service)

**Exec time hit**
Everyone tries not to use execs, but they work well in this case and over a number of tests I barely saw a `0.1 sec` difference, and that wasn't consistent so I think its a good solution.

Thanks for your consideration of this PR!