### PR TITLE
Support logging to NFLOG group

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -171,6 +171,7 @@ The following parameters are available in the `nftables` class:
 * [`log_prefix`](#-nftables--log_prefix)
 * [`log_discarded`](#-nftables--log_discarded)
 * [`log_limit`](#-nftables--log_limit)
+* [`log_group`](#-nftables--log_group)
 * [`reject_with`](#-nftables--reject_with)
 * [`in_out_conntrack`](#-nftables--in_out_conntrack)
 * [`in_out_drop_invalid`](#-nftables--in_out_drop_invalid)
@@ -330,6 +331,15 @@ to the rules that log discarded traffic. Set to false to
 disable rate limiting.
 
 Default value: `'3/minute burst 5 packets'`
+
+##### <a name="-nftables--log_group"></a>`log_group`
+
+Data type: `Optional[Integer]`
+
+When specified, the Linux kernel will pass the packet to nfnetlink_log
+which will send the log through a netlink socket to the specified group.
+
+Default value: `undef`
 
 ##### <a name="-nftables--reject_with"></a>`reject_with`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -334,7 +334,7 @@ Default value: `'3/minute burst 5 packets'`
 
 ##### <a name="-nftables--log_group"></a>`log_group`
 
-Data type: `Optional[Integer]`
+Data type: `Optional[Integer[0]]`
 
 When specified, the Linux kernel will pass the packet to nfnetlink_log
 which will send the log through a netlink socket to the specified group.

--- a/manifests/inet_filter.pp
+++ b/manifests/inet_filter.pp
@@ -3,7 +3,8 @@ class nftables::inet_filter inherits nftables {
   $_reject_rule = epp('nftables/reject_rule.epp',
     {
       'log_prefix' => sprintf($nftables::log_prefix, { 'chain' => '%<chain>s', 'comment' => 'Rejected: ' }),
-      'log_limit'  => $nftables::log_limit
+      'log_limit'  => $nftables::log_limit,
+      'log_group'  => $nftables::log_group,
     }
   )
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,6 +72,10 @@
 #  to the rules that log discarded traffic. Set to false to
 #  disable rate limiting.
 #
+# @param log_group
+#  When specified, the Linux kernel will pass the packet to nfnetlink_log
+#  which will send the log through a netlink socket to the specified group.
+#
 # @param reject_with
 #   How to discard packets not matching any rule. If `false`, the
 #   fate of the packet will be defined by the chain policy (normally
@@ -147,6 +151,7 @@ class nftables (
   Hash $rules = {},
   Hash $sets = {},
   String $log_prefix = '[nftables] %<chain>s %<comment>s',
+  Optional[Integer[0]] $log_group = undef,
   String[1] $nat_table_name = 'nat',
   Stdlib::Unixpath $inmem_rules_hash_file = '/var/tmp/puppet-nft-memhash',
   Boolean $log_discarded = true,

--- a/spec/classes/inet_filter_spec.rb
+++ b/spec/classes/inet_filter_spec.rb
@@ -571,6 +571,39 @@ describe 'nftables' do
         }
       end
 
+      context 'custom log group' do
+        let(:params) do
+          {
+            log_group: 1,
+            log_limit: '5/minute',
+          }
+        end
+
+        it {
+          expect(subject).to contain_concat__fragment('nftables-inet-filter-chain-INPUT-rule-log_discarded').with(
+            target: 'nftables-inet-filter-chain-INPUT',
+            content: %r{^  limit rate 5/minute log prefix "\[nftables\] INPUT Rejected: " group 1$},
+            order: '97-nftables-inet-filter-chain-INPUT-rule-log_discarded-b'
+          )
+        }
+
+        it {
+          expect(subject).to contain_concat__fragment('nftables-inet-filter-chain-OUTPUT-rule-log_discarded').with(
+            target: 'nftables-inet-filter-chain-OUTPUT',
+            content: %r{^  limit rate 5/minute log prefix "\[nftables\] OUTPUT Rejected: " group 1$},
+            order: '97-nftables-inet-filter-chain-OUTPUT-rule-log_discarded-b'
+          )
+        }
+
+        it {
+          expect(subject).to contain_concat__fragment('nftables-inet-filter-chain-FORWARD-rule-log_discarded').with(
+            target: 'nftables-inet-filter-chain-FORWARD',
+            content: %r{^  limit rate 5/minute log prefix "\[nftables\] FORWARD Rejected: " group 1$},
+            order: '97-nftables-inet-filter-chain-FORWARD-rule-log_discarded-b'
+          )
+        }
+      end
+
       context 'no reject rule, use chain policy without explicit reject' do
         let(:params) do
           {

--- a/templates/reject_rule.epp
+++ b/templates/reject_rule.epp
@@ -1,5 +1,5 @@
 <% if $log_limit { -%>
-limit rate <%= $log_limit %> log prefix "<%= $log_prefix %>" flags all counter
-<% } else { -%>
-log prefix "<%= $log_prefix %>" flags all counter
-<% } -%>
+limit rate <%= $log_limit %><%= ' ' -%>
+<% } -%> log prefix "<%= $log_prefix %>"<% if $log_group { -%>
+ group <%= $log_group -%>
+<% } else { %> flags all counter<% } -%>


### PR DESCRIPTION
With specified `nftables::log_group` log messages will be send to appropriate `NFLOG` group.

The options `flags` and `group` are mutually exclusive.

with 
```yaml
nftables::log_group: 1
```
the rule should look like this:
```
limit rate 3/minute log prefix "[nftables] OUTPUT Rejected: " group 1
```