### PR TITLE
README: fix indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ outbound traffic:
 
 ```puppet
 class { 'nftables':
-    out_all => true,
+  out_all => true,
 }
 ```
 


### PR DESCRIPTION
Fix indentation of sample puppet code. Two spaces is standard.