### PR TITLE
file: Fix heredoc example

### DIFF
--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -1,7 +1,7 @@
 # @summary Insert a file into the nftables configuration
 # @example Include a file that includes other files
 #   nftables::file{'geoip':
-#     content => @("EOT"),
+#     content => @(EOT),
 #       include "/var/local/geoipsets/dbip/nftset/ipv4/*.ipv4"
 #       include "/var/local/geoipsets/dbip/nftset/ipv6/*.ipv6"
 #       |EOT

--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -1,10 +1,10 @@
 # @summary Insert a file into the nftables configuration
 # @example Include a file that includes other files
 #   nftables::file{'geoip':
-#     content => @(EOT)
+#     content => @("EOT"),
 #       include "/var/local/geoipsets/dbip/nftset/ipv4/*.ipv4"
 #       include "/var/local/geoipsets/dbip/nftset/ipv6/*.ipv6"
-#       |EOT,
+#       |EOT
 #   }
 #
 # @param label Unique name to include in filename.


### PR DESCRIPTION
Provided example would fail on syntax validation
```
Error: Could not parse for environment production: Heredoc without end-tagged line
```