### PR TITLE
fix #264 - ensure non-duplicate rule names for multiple icmp types

### DIFF
--- a/manifests/rules/out/icmp.pp
+++ b/manifests/rules/out/icmp.pp
@@ -11,7 +11,7 @@ class nftables::rules::out::icmp (
 ) {
   if $v4_types {
     $v4_types.each | String $icmp_type | {
-      nftables::rule { 'default_out-accept_icmpv4':
+      nftables::rule { "default_out-accept_icmpv4_${regsubst(split($icmp_type, ' ')[0], '-', '_', 'G')}":
         content => "ip protocol icmp icmp type ${icmp_type} accept",
         order   => $order,
       }
@@ -25,7 +25,7 @@ class nftables::rules::out::icmp (
 
   if $v6_types {
     $v6_types.each | String $icmp_type | {
-      nftables::rule { 'default_out-accept_icmpv6':
+      nftables::rule { "default_out-accept_icmpv6_${regsubst(split($icmp_type, ' ')[0], '-', '_', 'G')}":
         content => "ip6 nexthdr ipv6-icmp icmpv6 type ${icmp_type} accept",
         order   => $order,
       }

--- a/spec/classes/rules/out/icmp_spec.rb
+++ b/spec/classes/rules/out/icmp_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'nftables::rules::out::icmp' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'default options' do
+        it { is_expected.to compile.with_all_deps }
+
+        it { is_expected.to contain_nftables__rule('default_out-accept_icmp').with_content('meta l4proto { icmp, icmpv6} accept').with_order('10') }
+        it { is_expected.not_to contain_nftables__rule('default_out-accept_icmpv4') }
+        it { is_expected.not_to contain_nftables__rule('default_out-accept_icmpv6') }
+      end
+
+      context 'with custom ICMP types (v4 only)' do
+        let(:params) do
+          {
+            v4_types: ['echo-request limit rate 4/second', 'echo-reply'],
+          }
+        end
+
+        it { is_expected.to compile }
+
+        it {
+          expect(subject).to contain_nftables__rule('default_out-accept_icmpv4_echo_request').with(
+            content: 'ip protocol icmp icmp type echo-request limit rate 4/second accept',
+            order: '10'
+          )
+        }
+
+        it {
+          expect(subject).to contain_nftables__rule('default_out-accept_icmpv4_echo_reply').with(
+            content: 'ip protocol icmp icmp type echo-reply accept',
+            order: '10'
+          )
+        }
+
+        it {
+          expect(subject).to contain_nftables__rule('default_out-accept_icmpv6').with(
+            content: 'meta l4proto icmpv6 accept',
+            order: '10'
+          )
+        }
+      end
+
+      context 'with custom ICMP types (both v4 and v6)' do
+        let(:params) do
+          {
+            v4_types: ['echo-request limit rate 4/second', 'echo-reply'],
+            v6_types: %w[echo-reply nd-router-advert],
+          }
+        end
+
+        it { is_expected.to compile }
+
+        it {
+          expect(subject).to contain_nftables__rule('default_out-accept_icmpv4_echo_request').with(
+            content: 'ip protocol icmp icmp type echo-request limit rate 4/second accept',
+            order: '10'
+          )
+        }
+
+        it {
+          expect(subject).to contain_nftables__rule('default_out-accept_icmpv4_echo_reply').with(
+            content: 'ip protocol icmp icmp type echo-reply accept',
+            order: '10'
+          )
+        }
+
+        it {
+          expect(subject).to contain_nftables__rule('default_out-accept_icmpv6_echo_reply').with(
+            content: 'ip6 nexthdr ipv6-icmp icmpv6 type echo-reply accept',
+            order: '10'
+          )
+        }
+
+        it {
+          expect(subject).to contain_nftables__rule('default_out-accept_icmpv6_nd_router_advert').with(
+            content: 'ip6 nexthdr ipv6-icmp icmpv6 type nd-router-advert accept',
+            order: '10'
+          )
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Introduce tests and ensure non-duplicate rule names 