### PR TITLE
Drop Puppet 7 testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@
 
 name: CI
 
+# yamllint disable-line rule:truthy
 on:
   pull_request: {}
   push:
@@ -18,4 +19,4 @@ concurrency:
 jobs:
   puppet:
     name: Puppet
-    uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v2
+    uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,5 @@ jobs:
   puppet:
     name: Puppet
     uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v3
+    with:
+      unit_runs_on: 'cern-self-hosted'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,7 @@
 
 name: "Pull Request Labeler"
 
+# yamllint disable-line rule:truthy
 on:
   pull_request_target: {}
 

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,23 @@
+---
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
+name: 'Prepare Release'
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Module version to be released. Must be a valid semver string without leading v. (1.2.3)'
+        required: false
+
+jobs:
+  release_prep:
+    uses: 'voxpupuli/gha-puppet/.github/workflows/prepare_release.yml@v3'
+    with:
+      version: ${{ github.event.inputs.version }}
+      allowed_owner: 'voxpupuli'
+    secrets:
+      # Configure secrets here:
+      #  https://docs.github.com/en/actions/security-guides/encrypted-secrets
+      github_pat: '${{ secrets.PCCI_PAT_RELEASE_PREP }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@
 
 name: Release
 
+# yamllint disable-line rule:truthy
 on:
   push:
     tags:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   release:
     name: Release
-    uses: voxpupuli/gha-puppet/.github/workflows/release.yml@v2
+    uses: voxpupuli/gha-puppet/.github/workflows/release.yml@v3
     with:
       allowed_owner: 'voxpupuli'
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,3 @@ jobs:
       #  https://docs.github.com/en/actions/security-guides/encrypted-secrets
       username: ${{ secrets.PUPPET_FORGE_USERNAME }}
       api_key: ${{ secrets.PUPPET_FORGE_API_KEY }}
-
-  create-github-release:
-    name: Create GitHub Release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create GitHub release
-        uses: voxpupuli/gha-create-a-github-release@v1

--- a/.msync.yml
+++ b/.msync.yml
@@ -2,4 +2,4 @@
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
-modulesync_config_version: '9.3.0'
+modulesync_config_version: '9.4.0'

--- a/.msync.yml
+++ b/.msync.yml
@@ -2,4 +2,4 @@
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
-modulesync_config_version: '9.1.0'
+modulesync_config_version: '9.2.0'

--- a/.msync.yml
+++ b/.msync.yml
@@ -2,4 +2,4 @@
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
-modulesync_config_version: '9.2.0'
+modulesync_config_version: '9.3.0'

--- a/.sync.yml
+++ b/.sync.yml
@@ -6,3 +6,7 @@ spec/spec_helper_acceptance.rb:
   enabled_lint_checks:
     - parameter_documentation
     - parameter_types
+
+.github/workflows/ci.yml:
+  with:
+    unit_runs_on: 'cern-self-hosted'

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,0 @@
-{
-  "recommendations": [
-    "puppet.puppet-vscode",
-    "rebornix.Ruby"
-  ]
-}

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 group :test do
-  gem 'voxpupuli-test', '~> 8.0',   :require => false
+  gem 'voxpupuli-test', '~> 9.0',   :require => false
   gem 'coveralls',                  :require => false
   gem 'simplecov-console',          :require => false
   gem 'puppet_metadata', '~> 4.0',  :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ end
 gem 'rake', :require => false
 gem 'facter', ENV['FACTER_GEM_VERSION'], :require => false, :groups => [:test]
 
-puppetversion = ENV['PUPPET_GEM_VERSION'] || '~> 7.24'
+puppetversion = ENV['PUPPET_GEM_VERSION'] || [">= 7.24", "< 9"]
 gem 'puppet', puppetversion, :require => false, :groups => [:test]
 
 # vim: syntax=ruby

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1727,10 +1727,10 @@ Insert a file into the nftables configuration
 
 ```puppet
 nftables::file{'geoip':
-  content => @(EOT)
+  content => @(EOT),
     include "/var/local/geoipsets/dbip/nftset/ipv4/*.ipv4"
     include "/var/local/geoipsets/dbip/nftset/ipv6/*.ipv6"
-    |EOT,
+    |EOT
 }
 ```
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -242,7 +242,7 @@ class nftables (
       notify   => Service['nftables'],
     }
 
-    # Generate nftables hash upon changes to the nftables service 
+    # Generate nftables hash upon changes to the nftables service
     exec { 'nftables_generate_hash':
       command     => ["nft -s list ruleset | sha1sum > ${inmem_rules_hash_file}"],
       path        => $facts['path'],

--- a/metadata.json
+++ b/metadata.json
@@ -83,7 +83,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     }
   ]
 }

--- a/spec/support/spec/mock.rb
+++ b/spec/support/spec/mock.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.configure do |c|
+  c.before do
+    # select the systemd service provider even when on docker
+    # https://tickets.puppetlabs.com/browse/PUP-11167
+    allow(Puppet::FileSystem).to receive(:exist?).and_call_original
+    allow(Puppet::FileSystem).to receive(:exist?).with('/proc/1/comm').and_return(true)
+    allow(Puppet::FileSystem).to receive(:read).and_call_original
+    allow(Puppet::FileSystem).to receive(:read).with('/proc/1/comm').and_return(['systemd'])
+  end
+end


### PR DESCRIPTION
Puppet 7 requires legacy facts, which we don't have available anymore. Also Puppet 7 is EoL soon. Technically the module works on Puppet 7, just unit tests fail.

also contains https://github.com/voxpupuli/puppet-nftables/pull/250