### PR TITLE
Correct nomad http api port opening

### DIFF
--- a/manifests/rules/nomad.pp
+++ b/manifests/rules/nomad.pp
@@ -22,7 +22,7 @@ class nftables::rules::nomad (
   # Open http api port to everything.
   #
   nftables::rule { 'default_in-nomad_http':
-    content => "tcp dport ${http}",
+    content => "tcp dport ${http} accept",
   }
 
   ['ip','ip6'].each | $_family | {

--- a/spec/classes/rules/nomad_spec.rb
+++ b/spec/classes/rules/nomad_spec.rb
@@ -29,7 +29,7 @@ describe 'nftables::rules::nomad' do
         }
 
         it {
-          is_expected.to contain_nftables__rule('default_in-nomad_http').with_content('tcp dport 4646')
+          is_expected.to contain_nftables__rule('default_in-nomad_http').with_content('tcp dport 4646 accept')
           is_expected.to contain_nftables__rule('default_in-nomad_rpc_ip6').with_content('tcp dport 4647 ip6 saddr @nomad_ip6 accept')
           is_expected.to contain_nftables__rule('default_in-nomad_rpc_ip').with_content('tcp dport 4647 ip saddr @nomad_ip accept')
           is_expected.to contain_nftables__rule('default_in-nomad_serf_tcp_ip6').with_content('tcp dport 4648 ip6 saddr @nomad_ip6 accept')
@@ -56,7 +56,7 @@ describe 'nftables::rules::nomad' do
         }
 
         it {
-          is_expected.to contain_nftables__rule('default_in-nomad_http').with_content('tcp dport 1000')
+          is_expected.to contain_nftables__rule('default_in-nomad_http').with_content('tcp dport 1000 accept')
           is_expected.to contain_nftables__rule('default_in-nomad_rpc_ip6').with_content('tcp dport 2000 ip6 saddr @nomad_ip6 accept')
           is_expected.to contain_nftables__rule('default_in-nomad_rpc_ip').with_content('tcp dport 2000 ip saddr @nomad_ip accept')
           is_expected.to contain_nftables__rule('default_in-nomad_serf_tcp_ip6').with_content('tcp dport 3000 ip6 saddr @nomad_ip6 accept')
@@ -85,7 +85,7 @@ describe 'nftables::rules::nomad' do
         it { is_expected.not_to contain_nftables__set('nomad_ip6') }
 
         it {
-          is_expected.to contain_nftables__rule('default_in-nomad_http').with_content('tcp dport 4646')
+          is_expected.to contain_nftables__rule('default_in-nomad_http').with_content('tcp dport 4646 accept')
           is_expected.not_to contain_nftables__rule('default_in-nomad_rpc_ip6')
           is_expected.to contain_nftables__rule('default_in-nomad_rpc_ip').with_content('tcp dport 4647 ip saddr @nomad_ip accept')
           is_expected.not_to contain_nftables__rule('default_in-nomad_serf_tcp_ip6')


### PR DESCRIPTION
#### Pull Request (PR) description

The nomad api port was being matched but was not be accepted.
