### PR TITLE
Add nftables::rules::mosh

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -29,6 +29,7 @@ Enable this option to support Ceph's Monitor Daemon.
 * [`nftables::rules::ldap`](#nftables--rules--ldap): manage in ldap
 * [`nftables::rules::llmnr`](#nftables--rules--llmnr): allow incoming Link-Local Multicast Name Resolution
 * [`nftables::rules::mdns`](#nftables--rules--mdns): allow incoming multicast DNS
+* [`nftables::rules::mosh`](#nftables--rules--mosh): manage in mosh
 * [`nftables::rules::multicast`](#nftables--rules--multicast): allow incoming multicast traffic
 * [`nftables::rules::nfs`](#nftables--rules--nfs): manage in nfs4
 * [`nftables::rules::nfs3`](#nftables--rules--nfs3): manage in nfs3
@@ -863,6 +864,24 @@ Data type: `Array[String[1]]`
 name for incoming interfaces to filter
 
 Default value: `[]`
+
+### <a name="nftables--rules--mosh"></a>`nftables::rules::mosh`
+
+manage in mosh
+
+#### Parameters
+
+The following parameters are available in the `nftables::rules::mosh` class:
+
+* [`ports`](#-nftables--rules--mosh--ports)
+
+##### <a name="-nftables--rules--mosh--ports"></a>`ports`
+
+Data type: `Nftables::Port::Range`
+
+mosh port range
+
+Default value: `'60000-61000'`
 
 ### <a name="nftables--rules--multicast"></a>`nftables::rules::multicast`
 

--- a/manifests/rules/mosh.pp
+++ b/manifests/rules/mosh.pp
@@ -1,0 +1,10 @@
+# @summary manage in mosh
+# @param ports mosh port range
+class nftables::rules::mosh (
+  Nftables::Port::Range $ports = '60000-61000',
+) {
+  nftables::rule {
+    'default_in-mosh':
+      content => "udp dport ${ports} accept",
+  }
+}

--- a/spec/acceptance/all_rules_spec.rb
+++ b/spec/acceptance/all_rules_spec.rb
@@ -33,6 +33,7 @@ describe 'nftables class' do
       include nftables::rules::node_exporter
       include nftables::rules::nfs3
       include nftables::rules::ssh
+      include nftables::rules::mosh
       include nftables::rules::dhcpv6_client
       include nftables::rules::afs3_callback
       include nftables::rules::ospf

--- a/spec/classes/rules/mosh_spec.rb
+++ b/spec/classes/rules/mosh_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'nftables::rules::mosh' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'default options' do
+        it { is_expected.to compile }
+        it { is_expected.to contain_nftables__rule('default_in-mosh').with_content('udp dport 60000-61000 accept') }
+      end
+
+      context 'with ports set' do
+        let(:params) do
+          {
+            ports: '60000-60010',
+          }
+        end
+
+        it { is_expected.to compile }
+        it { is_expected.to contain_nftables__rule('default_in-mosh').with_content('udp dport 60000-60010 accept') }
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description

This commit adds a class for managing firewall input rules for mosh, the mobile shell. Mosh bootstraps over SSH and then starts a server process that listens on a UDP port between 60000 and 61000.

See: https://mosh.org/#usage

#### This Pull Request (PR) fixes the following issues

N/A