### PR TITLE
add `$chains` parameter for ease-of-use via hiera

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -169,7 +169,9 @@ The following parameters are available in the `nftables` class:
 * [`nat_table_name`](#-nftables--nat_table_name)
 * [`purge_unmanaged_rules`](#-nftables--purge_unmanaged_rules)
 * [`inmem_rules_hash_file`](#-nftables--inmem_rules_hash_file)
+* [`chains`](#-nftables--chains)
 * [`sets`](#-nftables--sets)
+* [`rules`](#-nftables--rules)
 * [`log_prefix`](#-nftables--log_prefix)
 * [`log_discarded`](#-nftables--log_discarded)
 * [`log_limit`](#-nftables--log_limit)
@@ -181,7 +183,6 @@ The following parameters are available in the `nftables` class:
 * [`fwd_drop_invalid`](#-nftables--fwd_drop_invalid)
 * [`firewalld_enable`](#-nftables--firewalld_enable)
 * [`noflush_tables`](#-nftables--noflush_tables)
-* [`rules`](#-nftables--rules)
 * [`configuration_path`](#-nftables--configuration_path)
 * [`nft_path`](#-nftables--nft_path)
 * [`echo`](#-nftables--echo)
@@ -297,11 +298,27 @@ will be stored.
 
 Default value: `'/var/tmp/puppet-nft-memhash'`
 
+##### <a name="-nftables--chains"></a>`chains`
+
+Data type: `Hash`
+
+Allows sourcing chain definitions directly from Hiera.
+
+Default value: `{}`
+
 ##### <a name="-nftables--sets"></a>`sets`
 
 Data type: `Hash`
 
 Allows sourcing set definitions directly from Hiera.
+
+Default value: `{}`
+
+##### <a name="-nftables--rules"></a>`rules`
+
+Data type: `Hash`
+
+Specify hashes of `nftables::rule`s via hiera
 
 Default value: `{}`
 
@@ -406,14 +423,6 @@ If specified only other existings tables will be flushed.
 If left unset all tables will be flushed via a `flush ruleset`
 
 Default value: `undef`
-
-##### <a name="-nftables--rules"></a>`rules`
-
-Data type: `Hash`
-
-Specify hashes of `nftables::rule`s via hiera
-
-Default value: `{}`
 
 ##### <a name="-nftables--configuration_path"></a>`configuration_path`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,8 +55,14 @@
 #   The name of the file where the hash of the in-memory rules
 #   will be stored.
 #
+# @param chains
+#   Allows sourcing chain definitions directly from Hiera.
+#
 # @param sets
 #   Allows sourcing set definitions directly from Hiera.
+#
+# @param rules
+#   Specify hashes of `nftables::rule`s via hiera
 #
 # @param log_prefix
 #   String that will be used as prefix when logging packets. It can contain
@@ -105,9 +111,6 @@
 #   If specified only other existings tables will be flushed.
 #   If left unset all tables will be flushed via a `flush ruleset`
 #
-# @param rules
-#   Specify hashes of `nftables::rule`s via hiera
-#
 # @param configuration_path
 #   The absolute path to the principal nftables configuration file. The default
 #   varies depending on the system, and is set in the module's data.
@@ -148,6 +151,7 @@ class nftables (
   Boolean $inet_filter = true,
   Boolean $nat = true,
   Boolean $purge_unmanaged_rules = false,
+  Hash $chains = {},
   Hash $rules = {},
   Hash $sets = {},
   String $log_prefix = '[nftables] %<chain>s %<comment>s',
@@ -289,6 +293,14 @@ class nftables (
 
   if $nat {
     include nftables::ip_nat
+  }
+
+  # inject custom chains e.g. from hiera
+  $chains.each |$n,$v| {
+    nftables::chain {
+      $n:
+        * => $v,
+    }
   }
 
   # inject custom rules e.g. from hiera


### PR DESCRIPTION
I've no idea why this was never implemented because it is quite handy to have.

 - I've re-generated `REFERENCE.md`
 - `bundle exec rake test` completed successfully locally
 - pinning `nftables` in my `Puppetfile` to this branch allows creating chains via hiera as expected