### PR TITLE
Add more info that the default config is still in use

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ and/or `nftables::nat` to `false` and build your whole nftables
 configuration from scratch by using the building blocks provided by
 this module. Look at `nftables::inet_filter` for inspiration.
 
+> **Warning: the default OS config may flush your un-managed tables.**
+> On most distributions the package ships a default `/etc/nftables.conf`
+> that begins with `flush ruleset`. By default this module does **not**
+> replace that file; it only appends its own `include` line to the end.
+> As a result every service reload runs the distro's `flush ruleset`
+> *before* this module's configuration is processed, wiping any tables
+> not managed by Puppet — even when you have set
+> `nftables::noflush_tables`, because the flush happens in the parent
+> config before `noflush_tables` ever applies.
+>
+> To avoid this, set `nftables::clobber_default_config` to `true` so the
+> module owns `/etc/nftables.conf` and the only flushing is the
+> `noflush_tables`-aware flush performed inside the module's own config.
+
 ## Rules Validation
 
 Initially puppet deploys all configuration to

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -422,6 +422,11 @@ Data type: `Optional[Array[Pattern[/^(ip|ip6|inet|arp|bridge|netdev)-[-a-zA-Z0-9
 If specified only other existings tables will be flushed.
 If left unset all tables will be flushed via a `flush ruleset`
 
+This only governs the flush performed inside the module's own config. It
+has no effect on a `flush ruleset` present in the OS provided
+`configuration_path`; set `clobber_default_config` to `true` to remove
+that. See `clobber_default_config` for details.
+
 Default value: `undef`
 
 ##### <a name="-nftables--configuration_path"></a>`configuration_path`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -111,6 +111,11 @@
 #   If specified only other existings tables will be flushed.
 #   If left unset all tables will be flushed via a `flush ruleset`
 #
+#   This only governs the flush performed inside the module's own config. It
+#   has no effect on a `flush ruleset` present in the OS provided
+#   `configuration_path`; set `clobber_default_config` to `true` to remove
+#   that. See `clobber_default_config` for details.
+#
 # @param configuration_path
 #   The absolute path to the principal nftables configuration file. The default
 #   varies depending on the system, and is set in the module's data.


### PR DESCRIPTION
Hey, it's bin a while since I used Puppet so this can be seen from a beginner view.

#### Pull Request (PR) description
I spend some time debugging this and I feel a bit embarrassed. Nevertheless I think we should add small hint in the documentation that the default os config file didn't get overwritten by puppet.

Maybe the README change is a bit to much, but for me that was the starting point for this module. 

#### This Pull Request (PR) fixes the following issues
It would save me some hours/frustration and also some tokens if this would be mentioned in the Documentation. To be fair, it is in the docs, but a small hint in the `purge_unmanaged_rules` would be really helpful I think.